### PR TITLE
[CW-124] Expose 'no_transform' and 'sync_transform' for asset uploads and imports.

### DIFF
--- a/examples/experimental/create_dataset_and_train.py
+++ b/examples/experimental/create_dataset_and_train.py
@@ -30,10 +30,14 @@ async def import_sample_assets(endpoint: DataEndpoint, dataset: Dataset) -> list
     async def on_ready(import_job: DataJob):
         assets.append(await import_job.result())
     for sample_asset in sample_assets_json:
-        job = await endpoint.import_asset_job(AssetImport(
-            url=sample_asset['asset_url'],
-            ground_truth=sample_asset['prediction'],
-        ), dataset.uuid)
+        job = await endpoint.import_asset_job(
+            asset_import=AssetImport(
+                url=sample_asset['asset_url'],
+                ground_truth=sample_asset['prediction'],
+            ),
+            dataset_uuid=dataset.uuid,
+            no_transform=True
+        )
         tasks.append(on_ready(job))
     await asyncio.gather(*tasks)
     log.info("imported %d assets to %s", len(assets), dataset.uuid)

--- a/eyepop/data/data_endpoint.py
+++ b/eyepop/data/data_endpoint.py
@@ -343,23 +343,57 @@ class DataEndpoint(Endpoint):
 
     """" Asset methods """
 
-    async def upload_asset_job(self, stream: BinaryIO, mime_type: str, dataset_uuid: str,
-                               dataset_version: int | None = None, external_id: str | None = None,
-                               on_ready: Callable[[DataJob], None] | None = None) -> DataJob | SyncDataJob:
+    async def upload_asset_job(
+            self,
+            stream: BinaryIO,
+            mime_type: str,
+            dataset_uuid: str,
+            dataset_version: int | None = None,
+            external_id: str | None = None,
+            sync_transform: bool | None = None,
+            no_transform: bool | None = None,
+            on_ready: Callable[[DataJob], None] | None = None
+    ) -> DataJob | SyncDataJob:
         session = DataClientSession(self, await self.data_base_url())
-        job = _UploadStreamJob(stream=stream, mime_type=mime_type, dataset_uuid=dataset_uuid,
-                               dataset_version=dataset_version, external_id=external_id, session=session,
-                               on_ready=on_ready, callback=self.metrics_collector)
+        job = _UploadStreamJob(
+            stream=stream,
+            mime_type=mime_type,
+            dataset_uuid=dataset_uuid,
+            dataset_version=dataset_version,
+            external_id=external_id,
+            sync_transform=sync_transform,
+            no_transform=no_transform,
+            session=session,
+            on_ready=on_ready,
+            callback=self.metrics_collector
+        )
         await self._task_start(job.execute())
         return job
 
-    async def import_asset_job(self, asset_import: AssetImport, dataset_uuid: str, dataset_version: int | None = None,
-                               external_id: str | None = None, partition: str | None = None,
-                               on_ready: Callable[[DataJob], None] | None = None) -> DataJob | SyncDataJob:
+    async def import_asset_job(
+            self,
+            asset_import: AssetImport,
+            dataset_uuid: str,
+            dataset_version: int | None = None,
+            external_id: str | None = None,
+            partition: str | None = None,
+            sync_transform: bool | None = None,
+            no_transform: bool | None = None,
+            on_ready: Callable[[DataJob], None] | None = None
+    ) -> DataJob | SyncDataJob:
         session = DataClientSession(self, await self.data_base_url())
-        job = _ImportFromJob(asset_import=asset_import, dataset_uuid=dataset_uuid, dataset_version=dataset_version,
-                             external_id=external_id, session=session, partition=partition,
-                             on_ready=on_ready, callback=self.metrics_collector)
+        job = _ImportFromJob(
+            asset_import=asset_import,
+            dataset_uuid=dataset_uuid,
+            dataset_version=dataset_version,
+            external_id=external_id,
+            sync_transform=sync_transform,
+            no_transform=no_transform,
+            session=session,
+            partition=partition,
+            on_ready=on_ready,
+            callback=self.metrics_collector
+        )
         await self._task_start(job.execute())
         return job
 

--- a/eyepop/data/data_jobs.py
+++ b/eyepop/data/data_jobs.py
@@ -1,6 +1,7 @@
 import json
 from asyncio import Queue
 from typing import Callable, BinaryIO
+from urllib.parse import quote_plus
 
 import aiohttp
 
@@ -26,50 +27,85 @@ class DataJob(Job):
 
 
 class _UploadStreamJob(DataJob):
-    def __init__(self, stream: BinaryIO, mime_type: str, dataset_uuid: str, dataset_version: int | None,
-                 external_id: str | None, session: ClientSession, on_ready: Callable[[DataJob], None] | None = None,
-                 callback: JobStateCallback | None = None):
+    def __init__(
+            self,
+            stream: BinaryIO,
+            mime_type: str,
+            dataset_uuid: str,
+            dataset_version: int | None,
+            external_id: str | None,
+            sync_transform: bool | None,
+            no_transform: bool | None,
+            session: ClientSession,
+            on_ready: Callable[[DataJob], None] | None = None,
+            callback: JobStateCallback | None = None
+    ):
         super().__init__(session, on_ready, callback)
         self.stream = stream
         self.mime_type = mime_type
         self.dataset_uuid = dataset_uuid
         self.dataset_version = dataset_version
         self.external_id = external_id
+        self.sync_transform = sync_transform
+        self.no_transform = no_transform
 
     async def _do_execute_job(self, queue: Queue, session: ClientSession):
         dataset_version_query = f"&dataset_version={self.dataset_version}" if self.dataset_version else ""
-        post_path: str
-        if self.external_id:
-            post_path = f"/assets?dataset_uuid={self.dataset_uuid}{dataset_version_query}&external_id={self.external_id}"
-        else:
-            post_path = f"/assets?dataset_uuid={self.dataset_uuid}{dataset_version_query}"
+        external_id_query = f"&external_id={quote_plus(self.external_id)}" if self.external_id else ""
 
-        async with await session.request_with_retry("POST", post_path, data=self.stream,
-                                                    content_type=self.mime_type,
-                                                    timeout=aiohttp.ClientTimeout(total=None, sock_read=60)) as resp:
+        post_path = f"/assets?dataset_uuid={self.dataset_uuid}{dataset_version_query}{external_id_query}"
+
+        if self.sync_transform is not None:
+            post_path = f"{post_path}&sync_transform={'true' if self.sync_transform else 'false'}"
+        if self.no_transform is not None:
+            post_path = f"{post_path}&no_transform={'true' if self.no_transform else 'false'}"
+
+        async with await session.request_with_retry(
+                method="POST",
+                url=post_path,
+                data=self.stream,
+                content_type=self.mime_type,
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=60)
+        ) as resp:
             result = Asset.model_validate(await resp.json())
             await queue.put(result)
 
 
 class _ImportFromJob(DataJob):
-    def __init__(self, asset_import: AssetImport, dataset_uuid: str, dataset_version: int | None,
-                 external_id: str | None, partition: str | None,
-                 session: ClientSession, on_ready: Callable[[DataJob], None] | None = None,
-                 callback: JobStateCallback | None = None):
+    def __init__(
+            self,
+            asset_import: AssetImport,
+            dataset_uuid: str,
+            dataset_version: int | None,
+            external_id: str | None,
+            partition: str | None,
+            sync_transform: bool | None,
+            no_transform: bool | None,
+            session: ClientSession,
+            on_ready: Callable[[DataJob], None] | None = None,
+            callback: JobStateCallback | None = None
+    ):
         super().__init__(session, on_ready, callback)
         self.asset_import = asset_import
         self.dataset_uuid = dataset_uuid
         self.dataset_version = dataset_version
         self.external_id = external_id
         self.partition = partition
+        self.sync_transform = sync_transform
+        self.no_transform = no_transform
 
     async def _do_execute_job(self, queue: Queue, session: ClientSession):
         dataset_version_query = f"&dataset_version={self.dataset_version}" if self.dataset_version else ""
-        external_id_query = f"&external_id={self.external_id}" if self.external_id else ""
-        partition_query = f"&partition={self.partition}" if self.partition else ""
+        external_id_query = f"&external_id={quote_plus(self.external_id)}" if self.external_id else ""
+        partition_query = f"&partition={quote_plus(self.partition)}" if self.partition else ""
 
         post_path = (f"/assets/imports?dataset_uuid={self.dataset_uuid}"
                      f"{dataset_version_query}{external_id_query}{partition_query}")
+
+        if self.sync_transform is not None:
+            post_path = f"{post_path}&sync_transform={'true' if self.sync_transform else 'false'}"
+        if self.no_transform is not None:
+            post_path = f"{post_path}&no_transform={'true' if self.no_transform else 'false'}"
 
         async with await session.request_with_retry(
                 "POST",

--- a/eyepop/data/data_syncify.py
+++ b/eyepop/data/data_syncify.py
@@ -121,21 +121,43 @@ class SyncDataEndpoint(SyncEndpoint):
 
     """" Asset methods """
 
-    def upload_asset_job(self, stream: BinaryIO, mime_type: str, dataset_uuid: str,
-                         dataset_version: int | None = None, external_id: str | None = None,
-                         on_ready: Callable[[DataJob], None] | None = None) -> DataJob | SyncDataJob:
+    def upload_asset_job(
+            self, stream: BinaryIO,
+            mime_type: str,
+            dataset_uuid: str,
+            dataset_version: int | None = None,
+            external_id: str | None = None,
+            sync_transform: bool | None = None,
+            no_transform: bool | None = None,
+            on_ready: Callable[[DataJob], None] | None = None
+    ) -> DataJob | SyncDataJob:
         if on_ready is not None:
             raise TypeError("'on_ready' callback not supported for sync endpoints. "
                             "Use 'EyePopSdk.dataEndpoint(is_async=True)` to create "
                             "an endpoint with callback support")
         job = run_coro_thread_save(self.event_loop,
-                                   self.endpoint.upload_asset_job(stream, mime_type, dataset_uuid, dataset_version,
-                                                                   external_id, None))
+                                   self.endpoint.upload_asset_job(
+                                       stream=stream,
+                                       mime_type=mime_type,
+                                       dataset_uuid=dataset_uuid,
+                                       dataset_version=dataset_version,
+                                       external_id=external_id,
+                                       sync_transform=sync_transform,
+                                       no_transform=no_transform,
+                                       on_ready=None))
         return SyncDataJob(job, self.event_loop)
 
-    def import_asset_job(self, asset_import: AssetImport, dataset_uuid: str, dataset_version: Optional[int] = None,
-                         external_id: Optional[str] = None, partition: Optional[str] = None,
-                         on_ready: Callable[[DataJob], None] | None = None) -> DataJob | SyncDataJob:
+    def import_asset_job(
+            self,
+            asset_import: AssetImport,
+            dataset_uuid: str,
+            dataset_version: Optional[int] = None,
+            external_id: Optional[str] = None,
+            partition: Optional[str] = None,
+            sync_transform: bool | None = None,
+            no_transform: bool | None = None,
+            on_ready: Callable[[DataJob], None] | None = None
+    ) -> DataJob | SyncDataJob:
         if on_ready is not None:
             raise TypeError("'on_ready' callback not supported for sync endpoints. "
                             "Use 'EyePopSdk.dataEndpoint(is_async=True)` to create "
@@ -147,6 +169,8 @@ class SyncDataEndpoint(SyncEndpoint):
                                        dataset_version=dataset_version,
                                        external_id=external_id,
                                        partition=partition,
+                                       sync_transform=sync_transform,
+                                       no_transform=no_transform,
                                        on_ready=None))
         return SyncDataJob(job, self.event_loop)
 

--- a/eyepop/data/data_types.py
+++ b/eyepop/data/data_types.py
@@ -281,6 +281,7 @@ class Asset(BaseModel):
     updated_at: datetime | None = None
     mime_type: str | None = None
     file_size_bytes: int | None = None
+    is_transformed: bool | None = None
     status: AssetStatus | None = None
     status_message: str | None = None
     external_id: str | None = None
@@ -288,6 +289,7 @@ class Asset(BaseModel):
     review_priority: float | None = None
     model_relevance: float | None = None
     annotations: List[AssetAnnotation] = []
+
 
     ###
     # Denormalized attributes, for convenient serialization/storage detached of a dataset context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eyepop"
-version = "1.18.0"
+version = "1.19.0"
 description="EyePop.ai Python SDK"
 readme = "README.md"
 license.file = "./LICENSE"


### PR DESCRIPTION
**no_transform**

By default all imported and uploaded assets are parsed for correctness of a well known image format, converted into jpeg and stored in up to 6 diffent resolutions.

with 'no_transform=true' we will only store the original upload/imported file, accept it without file format validation and accepting the posted mime type, possibly application/octet-stream.

Any download of such asset will return the original file, regardless of the requested transcode mode. Consequently, the download of such an asset could result in an invalid/unknown file format or even a zero length response.

**sync_transform**

By default all *imported* assets are transformed synchronously - i.e. - when the job completes sucessfully it is guaranteed to be available. All *uploaded* assets are transformed asynchronously - i.e. they will stay in "in_progress" even after the job completes successfully.

With the bool flag 'sync_transform' the client can override this behaviour.

_'sync_transform' is ignored when 'no_transform' is set to true._