### PR TITLE
[AIW-34:SDK]: Add persist parameter for persistent sessions

### DIFF
--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -90,6 +90,9 @@ async def fetch_new_compute_session(
                 body["pipeline_image"] = compute_ctx.pipeline_image
             if compute_ctx.pipeline_version:
                 body["pipeline_version"] = compute_ctx.pipeline_version
+            if compute_ctx.persist:
+                body["persist"] = True
+                body["pop_uuid"] = compute_ctx.pop_uuid
 
             if body:
                 log.debug(f"POST /v1/sessions body: {body}")

--- a/eyepop/compute/context.py
+++ b/eyepop/compute/context.py
@@ -40,6 +40,14 @@ class ComputeContext(BaseModel):
         description="Custom Docker image tag for the worker pipeline",
         default_factory=lambda: os.getenv("EYEPOP_PIPELINE_VERSION", "")
     )
+    persist: bool = Field(
+        description="Create a persistent session that survives disconnects",
+        default=False
+    )
+    pop_uuid: str = Field(
+        description="The pop UUID for persistent session lookup",
+        default=""
+    )
 
 
 class PipelineStatus(str, Enum):

--- a/eyepop/eyepopsdk.py
+++ b/eyepop/eyepopsdk.py
@@ -158,7 +158,7 @@ class EyePopSdk:
 
         is_transient_pop = pop_id == "transient"
 
-        if api_key and not is_transient_pop:
+        if api_key and not is_transient_pop and not persist:
             raise ValueError(
                 f"EYEPOP_API_KEY can only be used with transient pops. "
                 f"Current pop_id: '{pop_id}'. Use EYEPOP_SECRET_KEY for named pops."
@@ -168,7 +168,7 @@ class EyePopSdk:
         if is_compute_url:
             if not api_key:
                 raise ValueError(f"Compute API endpoint ({eyepop_url}) requires EYEPOP_API_KEY")
-            if not is_transient_pop:
+            if not is_transient_pop and not persist:
                 raise ValueError(f"Compute API only supports transient mode. Current pop_id: '{pop_id}'")
 
         if is_local_mode and api_key is None:

--- a/eyepop/eyepopsdk.py
+++ b/eyepop/eyepopsdk.py
@@ -6,6 +6,7 @@ from typing_extensions import deprecated
 from eyepop import __version__
 from eyepop.data.data_endpoint import DataEndpoint
 from eyepop.data.data_syncify import SyncDataEndpoint
+from eyepop.exceptions import PopConfigurationException
 from eyepop.worker.worker_endpoint import WorkerEndpoint
 from eyepop.worker.worker_syncify import SyncWorkerEndpoint
 
@@ -85,6 +86,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            persist: bool = False,
     ) -> SyncWorkerEndpoint:
         endpoint = EyePopSdk.async_worker(
             pop_id=pop_id,
@@ -101,6 +103,7 @@ class EyePopSdk:
             dataset_uuid=dataset_uuid,
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
+            persist=persist,
         )
         return SyncWorkerEndpoint(endpoint)
 
@@ -120,6 +123,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            persist: bool = False,
     ) -> WorkerEndpoint:
         if is_local_mode is None:
             local_mode_env = os.getenv("EYEPOP_LOCAL_MODE", "")
@@ -170,6 +174,11 @@ class EyePopSdk:
         if is_local_mode and api_key is None:
             api_key = "<local api key>"
 
+        if persist and (not pop_id or pop_id == "transient"):
+            raise PopConfigurationException("transient", "persist requires pop_id")
+        if session_uuid and pop_id and pop_id != "transient":
+            raise PopConfigurationException(pop_id, "cannot pass both pop_id and session_uuid")
+
         assert eyepop_url
         log.debug(f"EyePop URL: {eyepop_url}")
 
@@ -187,6 +196,7 @@ class EyePopSdk:
             dataset_uuid=dataset_uuid,
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
+            persist=persist,
         )
         return endpoint
 

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -63,6 +63,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            persist: bool = False,
     ):
         super().__init__(
             secret_key=secret_key,
@@ -78,12 +79,17 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         self.stop_jobs = stop_jobs
         self.dataset_uuid = dataset_uuid
 
+        self._persist = persist
+
         if self.compute_ctx:
             if pipeline_image:
                 self.compute_ctx.pipeline_image = pipeline_image
             if pipeline_version:
                 self.compute_ctx.pipeline_version = pipeline_version
-            self.is_dev_mode = not bool(session_uuid)
+            if persist:
+                self.compute_ctx.persist = True
+                self.compute_ctx.pop_uuid = pop_id
+            self.is_dev_mode = not bool(session_uuid) and not persist
         else:
             self.is_dev_mode = True
 
@@ -106,6 +112,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             return True
 
     async def _disconnect(self, timeout: float | None = None):
+        if self._persist:
+            return
         client_timeout = None
         if timeout is not None:
             client_timeout = aiohttp.ClientTimeout(total=timeout)
@@ -295,6 +303,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         return self.pop
 
     async def set_pop(self, pop: Pop):
+        if self._persist:
+            raise PopConfigurationException(self.pop_id, 'cannot modify a persistent session')
         if not self.is_dev_mode:
             raise PopConfigurationException(self.pop_id, 'set_pop not supported in production mode')
         response = await self.pipeline_patch('pop', content_type='application/json',

--- a/tests/test_persist_validation.py
+++ b/tests/test_persist_validation.py
@@ -1,0 +1,34 @@
+import pytest
+
+from eyepop import EyePopSdk
+from eyepop.exceptions import PopConfigurationException
+
+
+def test_persist_without_pop_id_raises():
+    with pytest.raises(PopConfigurationException, match="persist requires pop_id"):
+        EyePopSdk.sync_worker(
+            pop_id="transient",
+            api_key="test-key",
+            persist=True,
+        )
+
+
+def test_pop_id_and_session_uuid_raises():
+    with pytest.raises(PopConfigurationException, match="cannot pass both"):
+        EyePopSdk.sync_worker(
+            pop_id="abc-123",
+            session_uuid="xyz-789",
+            secret_key="test-key",
+        )
+
+
+def test_persist_false_does_not_raise():
+    """persist=False (default) should not trigger validation errors."""
+    # This will fail later when trying to connect, but should not fail on validation
+    endpoint = EyePopSdk.async_worker(
+        pop_id="transient",
+        api_key="test-key",
+        persist=False,
+    )
+    assert endpoint is not None
+    assert not endpoint._persist


### PR DESCRIPTION
## Summary

- Add `persist: bool = False` parameter to `sync_worker` and `async_worker`
- SDK-side validation: persist requires pop_id, cannot combine pop_id + session_uuid
- `set_pop()` guarded for persistent sessions (raises `PopConfigurationException`)
- Disconnect skips pipeline teardown for persistent sessions
- Passes `persist` and `pop_uuid` in compute API session POST body

## Jira

[AIW-34](https://eyepop.atlassian.net/browse/AIW-34)

## Related PRs

- eyepop-ai/eyepop-compute-api#249 — Compute API persistent session handler
- eyepop-ai/eyepop-session-sentinel#41 — Sentinel expiry guard

## Test plan

- [x] persist without pop_id raises PopConfigurationException
- [x] pop_id + session_uuid raises PopConfigurationException
- [x] persist=False (default) does not raise
- [x] All 117 existing tests pass