### PR TITLE
[docs]: Simplify README, env example, and examples guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@
 # Get your API key at https://dashboard.eyepop.ai
 
 EYEPOP_API_KEY=
-# EYEPOP_SECRET_KEY=
 # EYEPOP_ACCESS_TOKEN=
 
 # Optional: use a named pop from your dashboard. Defaults to "transient".

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
-PYTHONPATH=.
-EYEPOP_ACCESS_TOKEN=
-EYEPOP_SECRET_KEY=
-EYEPOP_POP_ID=
+# EyePop credentials — set ONE of these auth methods.
+# Get your API key at https://dashboard.eyepop.ai
+
+EYEPOP_API_KEY=
+# EYEPOP_SECRET_KEY=
+# EYEPOP_ACCESS_TOKEN=
+
+# Optional: use a named pop from your dashboard. Defaults to "transient".
+# EYEPOP_POP_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ CLAUDE.local.md
 !.claude/agents/
 !.claude/skills/
 !CLAUDE.md
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.15.1] - 2026-04-03
+
 ### Added
 - `pipeline_image` and `pipeline_version` parameters on `workerEndpoint()` for custom worker Docker images (also configurable via `EYEPOP_PIPELINE_IMAGE` and `EYEPOP_PIPELINE_VERSION` environment variables)
 - `videoChunkLengthSeconds` and `videoChunkOverlap` fields on `InferenceComponent` for chunked video processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.15.2] - 2026-04-27
+
+### Added
+- `mediaCacheSeconds` field on `InferenceComponent` to retain the last N seconds of live streams for replay and debugging.
+
 ## [3.15.1] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Credentials are read from environment variables. Set **one** auth method:
 
 | Variable | Description |
 |---|---|
-| `EYEPOP_API_KEY` | API key for transient pops (default). |
-| `EYEPOP_SECRET_KEY` | Secret key for named pops. |
+| `EYEPOP_API_KEY` | API key from your dashboard. |
 | `EYEPOP_ACCESS_TOKEN` | Pre-issued OAuth access token. |
 
 Optional:
@@ -39,8 +38,6 @@ Optional:
 | `EYEPOP_PIPELINE_IMAGE` | Custom worker Docker image. |
 | `EYEPOP_PIPELINE_VERSION` | Custom worker image tag. |
 | `EYEPOP_ACCOUNT_ID` | Required for some Data API calls. |
-
-> **API_KEY vs SECRET_KEY**: `EYEPOP_API_KEY` only works with transient pops. For named pops, use `EYEPOP_SECRET_KEY`.
 
 Use [python-dotenv](https://pypi.org/project/python-dotenv/) to load a `.env` file (see [`.env.example`](.env.example)).
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Cancel a job mid-stream with `job.cancel()`.
 Queue multiple uploads, then collect results:
 
 ```python
+file_paths = ['examples/example.jpg']  # replace with your paths
+
 with EyePopSdk.sync_worker() as endpoint:
     jobs = [endpoint.upload(p) for p in file_paths]
     for job in jobs:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Python SDK for EyePop.ai's inference and data APIs.
 
-- **Install**: `pip install eyepop`
-- **Requires**: Python 3.12+
-- **Examples**: see [`examples/`](examples/)
+```shell
+pip install eyepop
+```
+
+Requires Python 3.12+.
 
 ## Quickstart
 
@@ -12,11 +14,15 @@ Python SDK for EyePop.ai's inference and data APIs.
 from eyepop import EyePopSdk
 
 with EyePopSdk.sync_worker() as endpoint:
-    result = endpoint.upload('examples/example.jpg').predict()
+    result = endpoint.upload('photo.jpg').predict()
     print(result)
 ```
 
-Set `EYEPOP_API_KEY` in your environment (get one at [dashboard.eyepop.ai](https://dashboard.eyepop.ai)), or pass `api_key=...` to `sync_worker()`.
+Set `EYEPOP_API_KEY` in your environment (get one at [dashboard.eyepop.ai](https://dashboard.eyepop.ai)), or pass `api_key=...` to `sync_worker()`:
+
+```python
+endpoint = EyePopSdk.sync_worker(api_key='my-api-key', pop_id='my-pop-id')
+```
 
 ## Configuration
 
@@ -32,20 +38,7 @@ Optional:
 | Variable | Description |
 |---|---|
 | `EYEPOP_POP_ID` | Named pop ID. Defaults to `transient`. |
-| `EYEPOP_SESSION_UUID` | Reuse an existing worker session. |
-| `EYEPOP_URL` | Override API endpoint. |
-| `EYEPOP_LOCAL_MODE` | Connect to a worker at `127.0.0.1:8080`. |
-| `EYEPOP_PIPELINE_IMAGE` | Custom worker Docker image. |
-| `EYEPOP_PIPELINE_VERSION` | Custom worker image tag. |
 | `EYEPOP_ACCOUNT_ID` | Required for some Data API calls. |
-
-Use [python-dotenv](https://pypi.org/project/python-dotenv/) to load a `.env` file (see [`.env.example`](.env.example)).
-
-You can also pass credentials explicitly:
-
-```python
-endpoint = EyePopSdk.sync_worker(pop_id='my-pop-id', api_key='my-api-key')
-```
 
 ## Usage
 
@@ -55,7 +48,7 @@ endpoint = EyePopSdk.sync_worker(pop_id='my-pop-id', api_key='my-api-key')
 from eyepop import EyePopSdk
 
 with EyePopSdk.sync_worker() as endpoint:
-    result = endpoint.upload('examples/example.jpg').predict()
+    result = endpoint.upload('photo.jpg').predict()
     print(result)
 ```
 
@@ -65,7 +58,7 @@ with EyePopSdk.sync_worker() as endpoint:
 
 ```python
 with EyePopSdk.sync_worker() as endpoint:
-    with open('examples/example.jpg', 'rb') as file:
+    with open('photo.jpg', 'rb') as file:
         result = endpoint.upload_stream(file, 'image/jpeg').predict()
 ```
 
@@ -92,7 +85,7 @@ Cancel a job mid-stream with `job.cancel()`.
 Queue multiple uploads, then collect results:
 
 ```python
-file_paths = ['examples/example.jpg']  # replace with your paths
+file_paths = ['photo1.jpg', 'photo2.jpg']
 
 with EyePopSdk.sync_worker() as endpoint:
     jobs = [endpoint.upload(p) for p in file_paths]
@@ -114,7 +107,7 @@ async def main(paths):
         for p in paths:
             await endpoint.upload(p, on_ready=on_ready)
 
-asyncio.run(main(['examples/example.jpg'] * 100))
+asyncio.run(main(['photo1.jpg', 'photo2.jpg']))
 ```
 
 ### Visualize results
@@ -125,15 +118,13 @@ import matplotlib.pyplot as plt
 from eyepop import EyePopSdk
 
 with EyePopSdk.sync_worker() as endpoint:
-    result = endpoint.upload('examples/example.jpg').predict()
+    result = endpoint.upload('photo.jpg').predict()
 
-with Image.open('examples/example.jpg') as image:
+with Image.open('photo.jpg') as image:
     plt.imshow(image)
 EyePopSdk.plot(plt.gca()).prediction(result)
 plt.show()
 ```
-
-See [`examples/visualize_with_webui2.py`](examples/visualize_with_webui2.py) for an interactive viewer.
 
 ## Composable Pops
 
@@ -208,8 +199,6 @@ pop = Pop(components=[
 ])
 ```
 
-Full catalogue: face mesh, hand tracking, body pose, SAM segmentation, and more in [`examples/pop_demo.py`](examples/pop_demo.py).
-
 ## Data Endpoint
 
 Dataset management, VLM inference, and evaluation workflows.
@@ -256,28 +245,3 @@ async with EyePopSdk.dataEndpoint(is_async=True, job_queue_length=4) as endpoint
     response = await job.response
     print(response.model_dump_json(indent=2))
 ```
-
-See [`examples/infer_demo.py`](examples/infer_demo.py) for the complete flow.
-
-## Advanced
-
-### Custom worker image
-
-```python
-EyePopSdk.sync_worker(
-    pipeline_image='my-registry/my-worker:latest',
-    pipeline_version='1.0.0',
-)
-```
-
-Or set `EYEPOP_PIPELINE_IMAGE` and `EYEPOP_PIPELINE_VERSION`.
-
-### Local mode
-
-Connect to a local worker at `127.0.0.1:8080`:
-
-```python
-EyePopSdk.sync_worker(is_local_mode=True)
-```
-
-Or set `EYEPOP_LOCAL_MODE=true`.

--- a/README.md
+++ b/README.md
@@ -1,86 +1,124 @@
 # EyePop.ai Python SDK
-The EyePop.ai Python SDK provides convenient access to EyePop.ai's inference and data APIs from Python.
 
-## Requirements
-* Python 3.12+
+Python SDK for EyePop.ai's inference and data APIs.
 
-## Install
-```shell
-pip install eyepop
+- **Install**: `pip install eyepop`
+- **Requires**: Python 3.12+
+- **Examples**: see [`examples/`](examples/)
+
+## Quickstart
+
+```python
+from eyepop import EyePopSdk
+
+with EyePopSdk.sync_worker() as endpoint:
+    result = endpoint.upload('examples/example.jpg').predict()
+    print(result)
 ```
+
+Set `EYEPOP_API_KEY` in your environment (get one at [dashboard.eyepop.ai](https://dashboard.eyepop.ai)), or pass `api_key=...` to `sync_worker()`.
 
 ## Configuration
 
-The SDK reads the following environment variables by default:
+Credentials are read from environment variables. Set **one** auth method:
 
-| Variable | Required | Description |
-|---|---|---|
-| `EYEPOP_API_KEY` | Yes | API key from your [EyePop dashboard](https://dashboard.eyepop.ai) account. |
-| `EYEPOP_POP_ID` | No | Pop Id from your dashboard. Defaults to `"transient"` if not set. |
-| `EYEPOP_ACCOUNT_ID` | For Data API | Account UUID, required when using `EyePopSdk.dataEndpoint()`. |
-| `EYEPOP_PIPELINE_IMAGE` | No | Custom worker Docker image (e.g. a private registry image). |
-| `EYEPOP_PIPELINE_VERSION` | No | Custom worker image version/tag. |
+| Variable | Description |
+|---|---|
+| `EYEPOP_API_KEY` | API key for transient pops (default). |
+| `EYEPOP_SECRET_KEY` | Secret key for named pops. |
+| `EYEPOP_ACCESS_TOKEN` | Pre-issued OAuth access token. |
 
-We recommend using [python-dotenv](https://pypi.org/project/python-dotenv/) to load credentials from a `.env` file so they are not stored in source control.
+Optional:
+
+| Variable | Description |
+|---|---|
+| `EYEPOP_POP_ID` | Named pop ID. Defaults to `transient`. |
+| `EYEPOP_SESSION_UUID` | Reuse an existing worker session. |
+| `EYEPOP_URL` | Override API endpoint. |
+| `EYEPOP_LOCAL_MODE` | Connect to a worker at `127.0.0.1:8080`. |
+| `EYEPOP_PIPELINE_IMAGE` | Custom worker Docker image. |
+| `EYEPOP_PIPELINE_VERSION` | Custom worker image tag. |
+| `EYEPOP_ACCOUNT_ID` | Required for some Data API calls. |
+
+> **API_KEY vs SECRET_KEY**: `EYEPOP_API_KEY` only works with transient pops. For named pops, use `EYEPOP_SECRET_KEY`.
+
+Use [python-dotenv](https://pypi.org/project/python-dotenv/) to load a `.env` file (see [`.env.example`](.env.example)).
+
+You can also pass credentials explicitly:
+
+```python
+endpoint = EyePopSdk.sync_worker(pop_id='my-pop-id', api_key='my-api-key')
+```
+
+## Usage
+
+### Single image
 
 ```python
 from eyepop import EyePopSdk
 
-endpoint = EyePopSdk.sync_worker()
-endpoint.connect()
-# do work ....
-endpoint.disconnect()
+with EyePopSdk.sync_worker() as endpoint:
+    result = endpoint.upload('examples/example.jpg').predict()
+    print(result)
 ```
 
-Or pass credentials explicitly:
+`upload()` queues the file; `predict()` blocks until the result is ready. For videos or multi-frame containers, call `predict()` in a loop until it returns `None`.
+
+### Binary streams
 
 ```python
-endpoint = EyePopSdk.sync_worker(
-    pop_id='my-pop-id',
-    api_key='my-api-key',
-)
+with EyePopSdk.sync_worker() as endpoint:
+    with open('examples/example.jpg', 'rb') as file:
+        result = endpoint.upload_stream(file, 'image/jpeg').predict()
 ```
 
-## Usage Examples
-
-### Uploading and processing a single image
+### URLs (HTTP, RTSP, RTMP)
 
 ```python
-from eyepop import EyePopSdk
+with EyePopSdk.sync_worker() as endpoint:
+    result = endpoint.load_from('https://example.com/image.jpg').predict()
+```
 
+### Videos
 
-def upload_photo(file_path: str):
-    with EyePopSdk.sync_worker() as endpoint:
-        result = endpoint.upload(file_path).predict()
+```python
+with EyePopSdk.sync_worker() as endpoint:
+    job = endpoint.load_from('https://example.com/video.mp4')
+    while result := job.predict():
         print(result)
-
-
-upload_photo('examples/example.jpg')
 ```
-1. `EyePopSdk.sync_worker()` returns an endpoint object that authenticates and connects to a worker.
-2. Using `with ... endpoint:` automatically manages the connection lifecycle. Alternatively, call
-`endpoint.connect()` and `endpoint.disconnect()` manually.
-3. `endpoint.upload(...)` uploads a local file to the worker. The image is queued and processed when the worker becomes available.
-4. `predict()` blocks until the next prediction result and returns it as a dict. For a single image there is one result; for videos or image containers (e.g. GIF), call `predict()` in a loop until it returns `None`.
 
-To upload a binary stream, use `upload_stream()` with the file-like object and MIME type:
+Cancel a job mid-stream with `job.cancel()`.
+
+### Batching
+
+Queue multiple uploads, then collect results:
 
 ```python
-from eyepop import EyePopSdk
-
-
-def upload_photo_from_stream(file_path: str, mime_type: str):
-    with EyePopSdk.sync_worker() as endpoint:
-        with open(file_path, 'rb') as file:
-            result = endpoint.upload_stream(file, mime_type).predict()
-            print(result)
-
-
-upload_photo_from_stream('examples/example.jpg', 'image/jpeg')
+with EyePopSdk.sync_worker() as endpoint:
+    jobs = [endpoint.upload(p) for p in file_paths]
+    for job in jobs:
+        print(job.predict())
 ```
 
-### Visualizing Results
-The SDK includes helper classes to visualize bounding boxes with `matplotlib.pyplot`.
+### Async with callbacks
+
+```python
+import asyncio
+from eyepop import EyePopSdk, Job
+
+async def main(paths):
+    async def on_ready(job: Job):
+        print(await job.predict())
+
+    async with EyePopSdk.async_worker() as endpoint:
+        for p in paths:
+            await endpoint.upload(p, on_ready=on_ready)
+
+asyncio.run(main(['examples/example.jpg'] * 100))
+```
+
+### Visualize results
 
 ```python
 from PIL import Image
@@ -89,218 +127,93 @@ from eyepop import EyePopSdk
 
 with EyePopSdk.sync_worker() as endpoint:
     result = endpoint.upload('examples/example.jpg').predict()
+
 with Image.open('examples/example.jpg') as image:
     plt.imshow(image)
-plot = EyePopSdk.plot(plt.gca())
-plot.prediction(result)
+EyePopSdk.plot(plt.gca()).prediction(result)
 plt.show()
 ```
-Depending on the environment, you might need an interactive backend (e.g. `pip install pyqt5`).
-See [visualize_with_webui2.py](examples/visualize_with_webui2.py) for a more comprehensive visualization example.
 
-### Uploading and processing batches of images
-Instead of waiting for each `predict()` before submitting the next job, queue all jobs first and collect results later. This avoids sequential accumulation of HTTP roundtrip time.
-
-```python
-from eyepop import EyePopSdk
-
-
-def upload_photos(file_paths: list[str]):
-    with EyePopSdk.sync_worker() as endpoint:
-        jobs = []
-        for file_path in file_paths:
-            jobs.append(endpoint.upload(file_path))
-        for job in jobs:
-            print(job.predict())
-
-
-upload_photos(['examples/example.jpg'] * 100)
-```
-### Asynchronous uploading and processing
-For large batches, use the `async` variant with `on_ready` callbacks to process results as they arrive:
-
-```python
-import asyncio
-from eyepop import EyePopSdk
-from eyepop import Job
-
-
-async def async_upload_photos(file_paths: list[str]):
-    async def on_ready(job: Job):
-        print(await job.predict())
-
-    async with EyePopSdk.async_worker() as endpoint:
-        for file_path in file_paths:
-            await endpoint.upload(file_path, on_ready=on_ready)
-
-
-asyncio.run(async_upload_photos(['examples/example.jpg'] * 100))
-```
-### Loading images from URLs
-Submit a publicly accessible URL for processing instead of uploading a file. Supported protocols:
-* HTTP(s) URLs with response Content-Type `image/*` or `video/*`
-* RTSP (live streaming)
-* RTMP (live streaming)
-
-```python
-from eyepop import EyePopSdk
-
-
-def load_from_url(url: str):
-    with EyePopSdk.sync_worker() as endpoint:
-        result = endpoint.load_from(url).predict()
-        print(result)
-
-
-load_from_url('https://farm2.staticflickr.com/1080/1301049949_532835a8b5_z.jpg')
-```
-### Processing Videos
-Process all frames of a video from a URL (or uploaded file). Call `predict()` in a loop:
-
-```python
-from eyepop import EyePopSdk
-
-
-def load_video_from_url(url: str):
-    with EyePopSdk.sync_worker() as endpoint:
-        job = endpoint.load_from(url)
-        while result := job.predict():
-            print(result)
-
-
-load_video_from_url('https://demo-eyepop-videos.s3.amazonaws.com/test1_vlog.mp4')
-```
-### Canceling Jobs
-Cancel any queued or in-progress job. For example, stop after 10 seconds of video:
-
-```python
-from eyepop import EyePopSdk
-
-
-def load_video_from_url(url: str):
-    with EyePopSdk.sync_worker() as endpoint:
-        job = endpoint.load_from(url)
-        while result := job.predict():
-            print(result)
-            if result['seconds'] >= 10.0:
-                job.cancel()
-
-
-load_video_from_url('https://demo-eyepop-videos.s3.amazonaws.com/test1_vlog.mp4')
-```
+See [`examples/visualize_with_webui2.py`](examples/visualize_with_webui2.py) for an interactive viewer.
 
 ## Composable Pops
 
-Composable Pops let you build multi-stage inference pipelines by chaining models and processing components together. Use `endpoint.set_pop(pop)` to configure a worker with a custom pipeline at runtime.
+Build multi-stage inference pipelines by chaining models. Configure at runtime with `endpoint.set_pop(pop)`.
 
 ### Components
 
 | Component | Purpose |
 |---|---|
-| `InferenceComponent` | Run an ML model (object detection, classification, segmentation, etc.). Supports `videoChunkLengthSeconds` and `videoChunkOverlap` for chunked video processing. |
-| `TrackingComponent` | Track detected objects across video frames |
-| `ContourFinderComponent` | Extract contours/polygons from segmentation masks |
-| `ComponentFinderComponent` | Extract connected components from masks |
-| `ForwardComponent` | Route outputs between pipeline stages |
+| `InferenceComponent` | Run a model. Supports chunked video via `videoChunkLengthSeconds` / `videoChunkOverlap`. |
+| `TrackingComponent` | Track detected objects across frames. |
+| `ContourFinderComponent` | Extract contours from segmentation masks. |
+| `ComponentFinderComponent` | Extract connected components from masks. |
+| `ForwardComponent` | Route outputs between stages. |
 
-### Forwarding Operators
+### Forwarding
 
-Components can forward their outputs to sub-components using:
+- **`CropForward`** — pass each detection crop to sub-components.
+- **`FullForward`** — pass the full image to sub-components.
 
-- **`CropForward`** — Crop each detected region and pass it to sub-components for further processing.
-- **`FullForward`** — Pass the full image to sub-components (e.g. for segmentation after detection).
+Both accept `includeClasses` to filter forwarded detections.
 
-Both support `includeClasses` to filter which detections get forwarded.
-
-### Example: Person Detection
-
-```python
-import asyncio
-from eyepop import EyePopSdk
-from eyepop.worker.worker_types import Pop, InferenceComponent
-
-pop = Pop(components=[
-    InferenceComponent(
-        ability='eyepop.person:latest',
-        categoryName="person"
-    )
-])
-
-async def main():
-    async with EyePopSdk.async_worker() as endpoint:
-        await endpoint.set_pop(pop)
-        job = await endpoint.upload('examples/example.jpg')
-        while result := await job.predict():
-            print(result)
-
-asyncio.run(main())
-```
-
-### Example: Vehicle Detection with License Plate OCR
-
-Chain models together: detect vehicles, crop each one, detect license plates within the crop, then read the text:
+### Example: Vehicle → License Plate → OCR
 
 ```python
 from eyepop.worker.worker_types import (
-    Pop, InferenceComponent, TrackingComponent,
-    CropForward, MotionModel,
+    Pop, InferenceComponent, TrackingComponent, CropForward, MotionModel,
 )
 
 pop = Pop(components=[
     InferenceComponent(
         ability='eyepop.vehicle:latest',
-        categoryName="vehicles",
+        categoryName='vehicles',
         confidenceThreshold=0.8,
-        forward=CropForward(
-            targets=[
-                TrackingComponent(
-                    maxAgeSeconds=5.0,
-                    motionModel=MotionModel.CONSTANT_VELOCITY,
-                    agnostic=True,
-                ),
-                InferenceComponent(
-                    ability='eyepop.vehicle.licence-plate:latest',
-                    topK=1,
-                    forward=CropForward(
-                        targets=[InferenceComponent(
-                            ability='eyepop.text.recognize.landscape:latest',
-                            categoryName="licence-plate"
-                        )]
-                    )
-                )
-            ]
-        )
-    )
+        forward=CropForward(targets=[
+            TrackingComponent(
+                maxAgeSeconds=5.0,
+                motionModel=MotionModel.CONSTANT_VELOCITY,
+                agnostic=True,
+            ),
+            InferenceComponent(
+                ability='eyepop.vehicle.licence-plate:latest',
+                topK=1,
+                forward=CropForward(targets=[
+                    InferenceComponent(
+                        ability='eyepop.text.recognize.landscape:latest',
+                        categoryName='licence-plate',
+                    ),
+                ]),
+            ),
+        ]),
+    ),
 ])
 ```
 
-### Example: Object Localization with VLM Prompts
-
-Use VLM abilities with custom prompts for open-vocabulary detection:
+### Example: VLM open-vocabulary detection
 
 ```python
 from eyepop.worker.worker_types import Pop, InferenceComponent, CropForward
 
 pop = Pop(components=[
     InferenceComponent(
-        id=1,
         ability='eyepop.localize-objects:latest',
-        params={"prompts": [{"prompt": "person"}]},
-        forward=CropForward(
-            targets=[InferenceComponent(
+        params={'prompts': [{'prompt': 'person'}]},
+        forward=CropForward(targets=[
+            InferenceComponent(
                 ability='eyepop.image-contents:latest',
-                params={"prompts": [{"prompt": "hair color?"}]}
-            )]
-        )
-    )
+                params={'prompts': [{'prompt': 'hair color?'}]},
+            ),
+        ]),
+    ),
 ])
 ```
 
-See [pop_demo.py](examples/pop_demo.py) for the full set of composable pop examples including face mesh, hand tracking, body pose, text detection, SAM segmentation, and more.
+Full catalogue: face mesh, hand tracking, body pose, SAM segmentation, and more in [`examples/pop_demo.py`](examples/pop_demo.py).
 
 ## Data Endpoint
 
-The Data Endpoint provides access to dataset management, VLM inference, and evaluation workflows.
+Dataset management, VLM inference, and evaluation workflows.
 
 ```python
 import asyncio
@@ -314,74 +227,58 @@ async def main():
 asyncio.run(main())
 ```
 
-### VLM Inference on Assets
-
-Run a VLM model against a single asset:
+### VLM inference on a single asset
 
 ```python
 from eyepop.data.data_types import InferRequest, TranscodeMode
 
-infer_request = InferRequest(
-    text_prompt='Describe what you see in this image.',
-)
-
 async with EyePopSdk.dataEndpoint(is_async=True) as endpoint:
     job = await endpoint.infer_asset(
         asset_uuid='your-asset-uuid',
-        infer_request=infer_request,
+        infer_request=InferRequest(text_prompt='Describe this image.'),
         transcode_mode=TranscodeMode.image_cover_1024,
     )
     while result := await job.predict():
         print(result)
 ```
 
-### Batch Dataset Evaluation
-
-Evaluate a VLM model across an entire dataset:
+### Batch dataset evaluation
 
 ```python
 from eyepop.data.data_types import EvaluateRequest, InferRequest
 
-evaluate_request = EvaluateRequest(
+request = EvaluateRequest(
     dataset_uuid='your-dataset-uuid',
-    infer=InferRequest(
-        text_prompt='How many people are in this image?',
-    ),
+    infer=InferRequest(text_prompt='How many people are in this image?'),
 )
 
 async with EyePopSdk.dataEndpoint(is_async=True, job_queue_length=4) as endpoint:
-    job = await endpoint.evaluate_dataset(evaluate_request=evaluate_request)
+    job = await endpoint.evaluate_dataset(evaluate_request=request)
     response = await job.response
     print(response.model_dump_json(indent=2))
 ```
 
-See [infer_demo.py](examples/infer_demo.py) for a complete VLM inference and evaluation example.
+See [`examples/infer_demo.py`](examples/infer_demo.py) for the complete flow.
 
-## Other Options
+## Advanced
 
-### Custom worker images
-To use a custom worker Docker image (e.g. from a private registry):
+### Custom worker image
+
 ```python
 EyePopSdk.sync_worker(
     pipeline_image='my-registry/my-worker:latest',
     pipeline_version='1.0.0',
 )
 ```
-Or set via environment variables `EYEPOP_PIPELINE_IMAGE` and `EYEPOP_PIPELINE_VERSION`.
+
+Or set `EYEPOP_PIPELINE_IMAGE` and `EYEPOP_PIPELINE_VERSION`.
 
 ### Local mode
-For local development against a worker running on `127.0.0.1:8080`:
+
+Connect to a local worker at `127.0.0.1:8080`:
+
 ```python
 EyePopSdk.sync_worker(is_local_mode=True)
 ```
-Or set the environment variable `EYEPOP_LOCAL_MODE=true`.
 
-## Release Process
-
-The SDK uses [setuptools-scm](https://github.com/pypa/setuptools-scm) for automatic versioning from git tags. To release:
-
-1. Merge your PR to `main`.
-2. Go to **Releases** > [Draft a new release](https://github.com/eyepop-ai/eyepop-sdk-python/releases/new).
-3. **Create a new tag** with the version number (e.g. `3.10.0`). Use semver: patch for fixes, minor for features, major for breaking changes.
-4. Fill in the release title and click **Generate Release Notes**.
-5. Click **Publish Release** to trigger the [GitHub Action](https://github.com/eyepop-ai/eyepop-sdk-python/actions) that builds and publishes to PyPI.
+Or set `EYEPOP_LOCAL_MODE=true`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,22 +1,54 @@
-# Get Started
-## Installation
+# EyePop SDK Examples
+
+Runnable scripts demonstrating common SDK workflows.
+
+## Setup
+
 ```shell
 cd examples
 python3 -m venv .venv
 . ./.venv/bin/activate
 pip install -r requirements.txt
 ```
-## Set Up Environment Variables
-### How to get an API key
-Sign in to [dashboard.eyepop.ai](https://dashboard.eyepop.ai) and create or find your API key under your profile settings.
-### Export them
+
+To run against your working copy of the SDK instead of PyPI:
+
 ```shell
-export EYEPOP_API_KEY=... # your API key
+pip install -e ..
 ```
-## Run an example script
+
+## Credentials
+
+Get an API key at [dashboard.eyepop.ai](https://dashboard.eyepop.ai), then either:
+
 ```shell
-python pop_demo.py \
-  --pop person \
-  --output \
-  --local-path ./example.jpg
+export EYEPOP_API_KEY=...
 ```
+
+…or copy `../.env.example` to `.env` and fill it in (all examples call `load_dotenv()`).
+
+## Running
+
+```shell
+python pop_demo.py --pop person --output --local-path ./example.jpg
+```
+
+Every example with CLI flags accepts `-h` / `--help`.
+
+## What's here
+
+| Script | Purpose |
+|---|---|
+| `pop_demo.py` | Compose multi-stage Pops (vehicles, faces, hands, SAM, VLM, tracking). The big one. |
+| `infer_demo.py` | Run VLM inference and dataset evaluation via the Data API. |
+| `caption_demo.py` | Generate captions via VLM/LLM. |
+| `upload_video.py` / `download_video.py` | Upload a local video; download a (trimmed) video asset. |
+| `upload_streaming.py` | Upload a binary stream with MIME type. |
+| `upload_image_timing.py` | Measure per-image upload + predict latency. |
+| `load_video_from_http.py` | Process a video by URL. |
+| `live_rtmp_stream.py` | Process a live RTMP stream. |
+| `visualize_on_image.py` | Overlay predictions on an image with matplotlib. |
+| `visualize_with_webui2.py` | Interactive web viewer for predictions. |
+| `import_dataset.py` | Import local assets into a dataset. |
+| `auth_session.py` | Browser-based OAuth session. |
+| `workflow_cli.py` | Argo workflow CLI helper. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ Get an API key at [dashboard.eyepop.ai](https://dashboard.eyepop.ai), then eithe
 export EYEPOP_API_KEY=...
 ```
 
-…or copy `../.env.example` to `.env` and fill it in (all examples call `load_dotenv()`).
+…or copy `../.env.example` to `.env` and fill it in. Examples that need credentials at startup (`pop_demo.py`, `auth_session.py`) call `load_dotenv()`; for others, export the variables in your shell.
 
 ## Running
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,4 @@
-eyepop~=3.11
+eyepop~=3.15
 click~=8.1
 matplotlib~=3.9
 Pillow~=10.4


### PR DESCRIPTION
## Summary
- README rewritten with Quickstart up front; env var table corrected (API_KEY vs SECRET_KEY vs ACCESS_TOKEN); Release Process section dropped (moved out of user-facing docs).
- examples/README expanded with a script inventory table, `.env` option, and `pip install -e ..` guidance.
- examples/requirements.txt version pin bumped from `eyepop~=3.11` to `~=3.15`.
- .env.example cleaned: dropped `PYTHONPATH`, added `EYEPOP_API_KEY`, commented alternatives.
- CHANGELOG: `[Unreleased]` entries moved under `[3.15.1] - 2026-04-03` (HEAD matches that tag).
- .gitignore: ignore `.claude/settings.local.json`.

## Test plan
- [x] `task check` (lint + typecheck + 114 tests) passes
- [ ] Reviewer reads rendered README on GitHub
- [ ] Reviewer confirms example script inventory matches `examples/` contents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **README simplified and reorganized** with Quickstart section first, clearer authentication guidance (clarifies EYEPOP_API_KEY vs EYEPOP_ACCESS_TOKEN), and condensed examples.
- **Environment template updated** to center on EYEPOP_API_KEY and removed PYTHONPATH and EYEPOP_SECRET_KEY references.
- **Examples documentation enhanced** with new script inventory table and support for .env file-based configuration.
- **Examples dependency bumped** from eyepop~=3.11 to eyepop~=3.15.
- **CHANGELOG updated** with new 3.15.2 release entry documenting mediaCacheSeconds field on InferenceComponent.
- **Build configuration updated** to ignore .claude/settings.local.json.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->