### PR TITLE
[OPA-34] Support mediaCacheSeconds to retain last X seconds of live streams

### DIFF
--- a/examples/pop_demo.py
+++ b/examples/pop_demo.py
@@ -42,6 +42,7 @@ script_dir = os.path.dirname(__file__)
 
 
 pop_examples = {
+    "noop": Pop(components=[]),
     "vehicles": Pop(components=[
         InferenceComponent(
             ability='eyepop.vehicle:latest',
@@ -351,6 +352,9 @@ parser.add_argument('--motion-detect', required=False, help="Skip video frames w
 # Optional global ROI parameters
 parser.add_argument('--roi', required=False, type=rectangle_roi, help="Rectangular ROI as (x, y, width, height)")
 
+# Optional caching media for post-processing on the worker
+parser.add_argument('-mc', '--media-cache-seconds', required=False, type=int, help="Cache most recent X seconds of media for post-processing on the worker", default=None)
+
 
 main_args = parser.parse_args()
 
@@ -535,7 +539,14 @@ async def main(args) -> tuple[dict[str, Any] | None, str | None]:
                     if args.output:
                         print(path, json.dumps(result, indent=2))
             for local_file in local_files:
-                job = await endpoint.upload(local_file, params=params, motion_detect=motion_detect, roi=args.roi, fps=args.fps)
+                job = await endpoint.upload(
+                    local_file,
+                    params=params,
+                    motion_detect=motion_detect,
+                    roi=args.roi,
+                    fps=args.fps,
+                    media_cache_seconds=args.media_cache_seconds
+                )
                 jobs.append(on_ready(job, local_file))
             await asyncio.gather(*jobs)
             if args.visualize and visualize_prediction is not None:
@@ -544,7 +555,14 @@ async def main(args) -> tuple[dict[str, Any] | None, str | None]:
                 image.save(buffer, format="PNG")
                 example_image_src = f"data:image/png;base64, {base64.b64encode(buffer.getvalue()).decode()}"
         elif args.url:
-            job = await endpoint.load_from(args.url, params=params, motion_detect=motion_detect, roi=args.roi, fps=args.fps)
+            job = await endpoint.load_from(
+                args.url,
+                params=params,
+                motion_detect=motion_detect,
+                roi=args.roi,
+                fps=args.fps,
+                media_cache_seconds=args.media_cache_seconds
+            )
             while result := await job.predict():
                 visualize_prediction = result
                 if args.output:
@@ -552,7 +570,14 @@ async def main(args) -> tuple[dict[str, Any] | None, str | None]:
             if args.visualize:
                 example_image_src = args.url
         elif args.asset_uuid:
-            job = await endpoint.load_asset(args.asset_uuid, params=params, motion_detect=motion_detect, roi=args.roi, fps=args.fps)
+            job = await endpoint.load_asset(
+                args.asset_uuid,
+                params=params,
+                motion_detect=motion_detect,
+                roi=args.roi,
+                fps=args.fps,
+                media_cache_seconds=args.media_cache_seconds
+            )
             while result := await job.predict():
                 visualize_prediction = result
                 if args.output:

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -24,7 +24,6 @@ from eyepop.worker.worker_jobs import (
     _UploadFileJob,
     _UploadStreamJob,
 )
-from eyepop.worker.worker_syncify import SyncWorkerJob
 from eyepop.worker.worker_types import ComponentParams, MotionDetectConfig, Pop, VideoMode
 
 log = logging.getLogger('eyepop')

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -319,8 +319,9 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: Callable[[WorkerJob], None] | None = None
-    ) -> WorkerJob | SyncWorkerJob:
+    ) -> WorkerJob:
         job = _UploadFileJob(
             location=location,
             video_mode=video_mode,
@@ -328,6 +329,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             session=self, on_ready=on_ready,
             callback=self.metrics_collector
         )
@@ -343,8 +345,9 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: Callable[[WorkerJob], None] | None = None
-    ) -> WorkerJob | SyncWorkerJob:
+    ) -> WorkerJob:
         job = _UploadStreamJob(
             stream=stream,
             mime_type=mime_type,
@@ -353,6 +356,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
             callback=self.metrics_collector
@@ -367,14 +371,16 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: Callable[[WorkerJob], None] | None = None
-    ) -> WorkerJob | SyncWorkerJob:
+    ) -> WorkerJob:
         job = _LoadFromJob(
             location=location,
             component_params=params,
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
             callback=self.metrics_collector
@@ -389,14 +395,16 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: Callable[[WorkerJob], None] | None = None
-    ) -> WorkerJob | SyncWorkerJob:
+    ) -> WorkerJob:
         job = _LoadFromAssetUuidJob(
             asset_uuid=asset_uuid,
             component_params=params,
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
             callback=self.metrics_collector

--- a/eyepop/worker/worker_jobs.py
+++ b/eyepop/worker/worker_jobs.py
@@ -30,6 +30,7 @@ class WorkerJob(Job):
     _roi: Area | None
     _fps: str | None
     _version: PredictionVersion
+    _media_cache_seconds: int | None
 
     def __init__(
             self,
@@ -38,6 +39,7 @@ class WorkerJob(Job):
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
             fps: str | None,
+            media_cache_seconds: int | None,
             on_ready: Callable[["WorkerJob"], None] | None,
             callback: JobStateCallback | None = None,
             version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
@@ -47,6 +49,7 @@ class WorkerJob(Job):
         self._motion_detect = motion_detect
         self._roi = roi
         self._fps = fps
+        self._media_cache_seconds = media_cache_seconds
         self._version = version
 
     async def predict(self) -> dict[str, Any] | None:
@@ -100,6 +103,7 @@ class _UploadJob(WorkerJob):
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
             fps: str | None,
+            media_cache_seconds: int | None,
             session: WorkerClientSession,
             on_ready: Callable[[WorkerJob], None] | None = None,
             callback: JobStateCallback | None = None,
@@ -111,6 +115,7 @@ class _UploadJob(WorkerJob):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             on_ready=on_ready,
             callback=callback,
             version=version
@@ -149,6 +154,8 @@ class _UploadJob(WorkerJob):
             query_params['version'] = self._version
         if self._motion_detect is not None:
             query_params.update(self._motion_detect.model_dump(exclude_none=True))
+        if self._media_cache_seconds is not None:
+            query_params['mediaCacheSeconds'] = self._media_cache_seconds
 
         if self.needs_full_duplex:
             self._response = await session.pipeline_post(
@@ -218,19 +225,21 @@ class _UploadFileJob(_UploadJob):
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
             fps: str | None,
+            media_cache_seconds: int | None,
             session: WorkerClientSession,
             on_ready: Callable[[WorkerJob], None] | None = None,
             callback: JobStateCallback | None = None,
             version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
     ):
         super().__init__(
-            mime_type=_guess_mime_type_from_location(location),
+            mime_type=_guess_mime_type_from_location(location) or 'application/octet-stream',
             open_stream=self._open_file_stream,
             video_mode=video_mode,
             component_params=component_params,
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             session=session,
             on_ready=on_ready,
             callback=callback,
@@ -252,6 +261,7 @@ class _UploadStreamJob(_UploadJob):
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
             fps: str | None,
+            media_cache_seconds: int | None,
             session: WorkerClientSession,
             on_ready: Callable[[WorkerJob], None] | None = None,
             callback: JobStateCallback | None = None,
@@ -265,6 +275,7 @@ class _UploadStreamJob(_UploadJob):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             session=session,
             on_ready=on_ready,
             callback=callback,
@@ -284,6 +295,7 @@ class _LoadFromJob(WorkerJob):
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
             fps: str | None,
+            media_cache_seconds: int | None,
             session: WorkerClientSession,
             on_ready: Callable[[WorkerJob], None] | None = None,
             callback: JobStateCallback | None = None,
@@ -295,13 +307,14 @@ class _LoadFromJob(WorkerJob):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             on_ready=on_ready,
             callback=callback,
             version=version
         )
         self.location = location
         self.target_url = 'source?mode=queue&processing=sync'
-        self.body = {
+        self.body: dict[str, Any] = {
             "sourceType": "URL",
             "url": self.location,
             "version": self._version,
@@ -314,6 +327,8 @@ class _LoadFromJob(WorkerJob):
             self.body['roi'] = self._roi.model_dump(exclude_none=True)
         if self._fps is not None:
             self.body['fps'] = self._fps
+        if self._media_cache_seconds is not None:
+            self.body['mediaCacheSeconds'] = self._media_cache_seconds
 
         self.timeouts = aiohttp.ClientTimeout(total=None, sock_read=600)
 
@@ -334,6 +349,7 @@ class _LoadFromAssetUuidJob(WorkerJob):
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
             fps: str | None,
+            media_cache_seconds: int | None,
             session: WorkerClientSession,
             on_ready: Callable[[WorkerJob], None] | None = None,
             callback: JobStateCallback | None = None,
@@ -345,6 +361,7 @@ class _LoadFromAssetUuidJob(WorkerJob):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
             on_ready=on_ready,
             callback=callback,
             version=version
@@ -362,6 +379,8 @@ class _LoadFromAssetUuidJob(WorkerJob):
             self.body['roi'] = self._roi.model_dump(exclude_none=True)
         if self._component_params is not None:
             self.body['params'] = TypeAdapter(list[ComponentParams]).dump_python(self._component_params)
+        if self._media_cache_seconds is not None:
+            self.body['mediaCacheSeconds'] = self._media_cache_seconds
 
         self.timeouts = aiohttp.ClientTimeout(total=None, sock_read=600)
 

--- a/eyepop/worker/worker_syncify.py
+++ b/eyepop/worker/worker_syncify.py
@@ -37,6 +37,7 @@ class SyncWorkerEndpoint(SyncEndpoint):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: typing.Callable[[WorkerJob], None] | None = None
     ) -> SyncWorkerJob:
         if on_ready is not None:
@@ -44,7 +45,15 @@ class SyncWorkerEndpoint(SyncEndpoint):
                 "'on_ready' callback not supported for sync endpoints. "
                 "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
         job = run_coro_thread_save(self.event_loop, self.endpoint.upload(
-            location=location, video_mode=video_mode, params=params, motion_detect=motion_detect, roi=roi, fps=fps, on_ready=None))
+            location=location,
+            video_mode=video_mode,
+            params=params,
+            motion_detect=motion_detect,
+            roi=roi,
+            fps=fps,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
+        ))
         return SyncWorkerJob(job, self.event_loop)
 
     def upload_stream(
@@ -56,6 +65,7 @@ class SyncWorkerEndpoint(SyncEndpoint):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: typing.Callable[[WorkerJob], None] | None = None
     ) -> SyncWorkerJob:
         if on_ready is not None:
@@ -63,7 +73,15 @@ class SyncWorkerEndpoint(SyncEndpoint):
                 "'on_ready' callback not supported for sync endpoints. "
                 "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
         job = run_coro_thread_save(self.event_loop, self.endpoint.upload_stream(
-            stream=stream, mime_type=mime_type, video_mode=video_mode, params=params, motion_detect=motion_detect, roi=roi, fps=fps, on_ready=None
+            stream=stream,
+            mime_type=mime_type,
+            video_mode=video_mode,
+            params=params,
+            motion_detect=motion_detect,
+            roi=roi,
+            fps=fps,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
         ))
         return SyncWorkerJob(job, self.event_loop)
 
@@ -74,6 +92,7 @@ class SyncWorkerEndpoint(SyncEndpoint):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: typing.Callable[[WorkerJob], None] | None = None
     ) -> SyncWorkerJob:
         if on_ready is not None:
@@ -81,7 +100,14 @@ class SyncWorkerEndpoint(SyncEndpoint):
                 "'on_ready' callback not supported for sync endpoints. "
                 "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
         job = run_coro_thread_save(self.event_loop, self.endpoint.load_from(
-            location=location, params=params, motion_detect=motion_detect, roi=roi, fps=fps, on_ready=None))
+            location=location,
+            params=params,
+            motion_detect=motion_detect,
+            roi=roi,
+            fps=fps,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
+        ))
         return SyncWorkerJob(job, self.event_loop)
 
     def load_asset(
@@ -91,6 +117,7 @@ class SyncWorkerEndpoint(SyncEndpoint):
             motion_detect: MotionDetectConfig | None = None,
             roi: Area | None = None,
             fps: str | None = None,
+            media_cache_seconds: int | None = None,
             on_ready: typing.Callable[[WorkerJob], None] | None = None
     ) -> SyncWorkerJob:
         if on_ready is not None:
@@ -98,7 +125,14 @@ class SyncWorkerEndpoint(SyncEndpoint):
                 "'on_ready' callback not supported for sync endpoints. "
                 "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
         job = run_coro_thread_save(self.event_loop, self.endpoint.load_asset(
-            asset_uuid=asset_uuid, params=params, motion_detect=motion_detect, roi=roi, fps=fps, on_ready=None))
+            asset_uuid=asset_uuid,
+            params=params,
+            motion_detect=motion_detect,
+            roi=roi,
+            fps=fps,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
+        ))
         return SyncWorkerJob(job, self.event_loop)
 
     def get_pop(self) -> Pop | None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Live stream media caching support**: Added `mediaCacheSeconds` parameter to retain the last X seconds of live stream data across upload, upload_stream, load_from, and load_asset operations.
- **Extended WorkerEndpoint API**: Updated `upload()`, `upload_stream()`, `load_from()`, and `load_asset()` methods with new optional `media_cache_seconds: int | None` parameter for controlling stream retention duration.
- **Extended SyncWorkerEndpoint API**: Added corresponding `media_cache_seconds` parameter to all synchronous wrapper methods to maintain API consistency.
- **Internal request handling**: Media cache seconds is propagated as a URL query parameter for upload jobs and as part of JSON request bodies for load-from operations.
- **CLI support**: Enhanced pop_demo.py example with `--media-cache-seconds` command-line flag to demonstrate the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->