### PR TITLE
[SDK] Health check fixes and debug logging cleanup

### DIFF
--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -46,35 +46,29 @@ async def fetch_new_compute_session(
     }
 
     sessions_url = f"{compute_ctx.compute_url}/v1/sessions"
-    log.debug(f"Fetching sessions from: {sessions_url}")
 
     res = None
     need_new_session = False
 
     try:
         async with client_session.get(sessions_url, headers=headers) as get_response:
+            log.debug(f"GET /v1/sessions - status: {get_response.status}")
             if get_response.status == 404:
                 need_new_session = True
-                log.debug("GET /v1/sessions returned 404, will create new session")
             else:
                 get_response.raise_for_status()
                 res = await get_response.json()
-                log.debug(f"GET /v1/sessions: {get_response.status}")
 
                 if not res:
                     need_new_session = True
-                    log.debug("Response is empty/None, need to create new session")
                 elif isinstance(res, list) and len(res) == 0:
                     need_new_session = True
-                    log.debug("Response is empty list, need to create new session")
                 elif isinstance(res, dict) and not res.get("session_uuid"):
                     need_new_session = True
-                    log.debug("Response is dict without session_uuid, need to create new session")
 
     except aiohttp.ClientResponseError as e:
         if e.status == 404:
             need_new_session = True
-            log.debug("GET /v1/sessions returned 404, will create new session")
         else:
             raise ComputeSessionException(
                 f"Failed to fetch existing sessions: {e.message}",
@@ -84,18 +78,12 @@ async def fetch_new_compute_session(
 
     if need_new_session:
         try:
-            log.debug(f"Creating new session via POST to: {sessions_url}")
             body = {}
             if compute_ctx.pipeline_image:
                 body["pipeline_image"] = compute_ctx.pipeline_image
             if compute_ctx.pipeline_version:
                 body["pipeline_version"] = compute_ctx.pipeline_version
 
-            if body:
-                log.debug(f"POST /v1/sessions body: {body}")
-
-            # Explicit kwargs instead of **post_kwargs — the dict unpacking
-            # confuses aiohttp's overloaded signature and breaks type checking
             async with client_session.post(
                 f'{sessions_url}?wait=true',
                 headers=headers,
@@ -103,7 +91,7 @@ async def fetch_new_compute_session(
             ) as post_response:
                 post_response.raise_for_status()
                 res = await post_response.json()
-                log.debug(f"POST /v1/sessions response: {post_response.status}")
+                log.debug(f"POST /v1/sessions - status: {post_response.status}")
         except aiohttp.ClientResponseError as e:
             raise ComputeSessionException(
                 f"Failed to create new session: {e.message}",
@@ -176,32 +164,25 @@ async def refresh_compute_token(
     headers = {"Authorization": f"Bearer {compute_ctx.api_key}", "Accept": "application/json"}
 
     refresh_url = f"{compute_ctx.compute_url}/v1/auth/authenticate"
-    log.debug(f"Refreshing token at: {refresh_url}")
 
     try:
         async with client_session.post(refresh_url, headers=headers) as response:
             response.raise_for_status()
             token_response = await response.json()
-            log.debug(f"Token refresh response: {token_response}")
+            log.debug(f"POST /v1/auth/authenticate - status: {response.status}")
 
             compute_ctx.m2m_access_token = token_response.get("access_token", "")
             compute_ctx.access_token_expires_at = token_response.get("expires_at", "")
             compute_ctx.access_token_expires_in = token_response.get("expires_in", 0)
 
-            log.debug(
-                f"Token refreshed successfully, expires in: {compute_ctx.access_token_expires_in}s"
-            )
             return compute_ctx
 
     except aiohttp.ClientResponseError as e:
-        log.error(f"Failed to refresh token: HTTP {e.status} - {e.message}")
         raise ComputeTokenException(
             f"Token refresh failed: HTTP {e.status} - {e.message}",
             session_uuid=compute_ctx.session_uuid,
         ) from e
     except Exception as e:
-        log.error("Failed to refresh token")
-        log.debug(str(e))
         raise ComputeTokenException(
             f"Token refresh failed: {str(e)}", session_uuid=compute_ctx.session_uuid
         ) from e
@@ -218,13 +199,12 @@ async def fetch_permanent_compute_session(
     }
 
     session_url = f"{compute_ctx.compute_url}/v1/sessions/{permanent_session_uuid}"
-    log.debug(f"Fetching session from: {session_url}")
 
     try:
         async with client_session.get(session_url, headers=headers) as get_response:
             get_response.raise_for_status()
             res = await get_response.json()
-            log.debug(f"GET /v1/sessions: {get_response.status}")
+            log.debug(f"GET /v1/sessions/{permanent_session_uuid} - status: {get_response.status}")
             _compute_context_from_response(compute_ctx, res)
             return compute_ctx
     except aiohttp.ClientResponseError as e:

--- a/eyepop/compute/status.py
+++ b/eyepop/compute/status.py
@@ -39,10 +39,12 @@ async def wait_for_session(
     last_message = "No message received"
     attempt = 0
 
+    request_timeout = aiohttp.ClientTimeout(total=interval)
+
     while asyncio.get_event_loop().time() < end_time:
         attempt += 1
         try:
-            async with client_session.get(health_url, headers=headers) as response:
+            async with client_session.get(health_url, headers=headers, timeout=request_timeout) as response:
                 if response.status != 200:
                     last_message = f"HTTP {response.status}"
                     log.debug(f"GET /health - status: {response.status} (attempt {attempt})")
@@ -85,7 +87,7 @@ async def wait_for_session(
             last_message = f"HTTP {e.status}: {e.message}"
             log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
             await asyncio.sleep(interval)
-        except Exception as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as e:
             last_message = str(e)
             log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
             await asyncio.sleep(interval)

--- a/eyepop/compute/status.py
+++ b/eyepop/compute/status.py
@@ -3,8 +3,7 @@ import logging
 
 import aiohttp
 
-from eyepop.compute.context import ComputeContext, PipelineStatus
-from eyepop.compute.responses import ComputeApiSessionResponse
+from eyepop.compute.context import ComputeContext
 from eyepop.exceptions import ComputeHealthCheckException
 
 log = logging.getLogger("eyepop.compute")
@@ -16,7 +15,6 @@ async def wait_for_session(
     timeout = compute_config.wait_for_session_timeout
     interval = compute_config.wait_for_session_interval
 
-    # Session endpoint health check ALWAYS uses the JWT access_token
     if not compute_config.m2m_access_token or len(compute_config.m2m_access_token.strip()) == 0:
         raise ComputeHealthCheckException(
             "No access_token in compute_config. "
@@ -25,19 +23,13 @@ async def wait_for_session(
             session_endpoint=compute_config.session_endpoint,
         )
 
-    auth_header = f"Bearer {compute_config.m2m_access_token}"
-    log.debug(
-        f"Using JWT access_token for session health check at {compute_config.session_endpoint}/health"
-    )
-
     headers = {
-        "Authorization": auth_header,
+        "Authorization": f"Bearer {compute_config.m2m_access_token}",
         "Accept": "application/json",
     }
 
     health_url = f"{compute_config.session_endpoint}/health"
-    log.debug(f"Waiting for session to be ready at: {health_url}")
-    log.debug(f"Timeout: {timeout}s, Interval: {interval}s")
+    log.debug(f"Waiting for session ready: {health_url} (timeout={timeout}s, interval={interval}s)")
 
     end_time = asyncio.get_event_loop().time() + timeout
     last_message = "No message received"
@@ -46,56 +38,24 @@ async def wait_for_session(
     while asyncio.get_event_loop().time() < end_time:
         attempt += 1
         try:
-            log.debug(f"Health check attempt {attempt}")
-
             async with client_session.get(health_url, headers=headers) as response:
-                log.debug(f"Health check response status: {response.status}")
+                log.debug(f"GET /health - status: {response.status} (attempt {attempt})")
 
                 if response.status == 200:
-                    log.debug("Session is ready (status 200)")
                     return True
 
-                if response.status != 200:
-                    last_message = f"Health check returned status {response.status}"
-                    log.debug(last_message)
-                    await asyncio.sleep(interval)
-                    continue
-
-                session_response = ComputeApiSessionResponse(**(await response.json()))
-                status = session_response.session_status
-
-                if status == PipelineStatus.RUNNING:
-                    log.debug("Session is running")
-                    return True
-                elif status == PipelineStatus.PENDING:
-                    last_message = f"Session status: {status.value}"
-                    log.debug(f"Session still pending/creating: {last_message}")
-                    await asyncio.sleep(interval)
-                    continue
-                elif status in [
-                    PipelineStatus.FAILED,
-                    PipelineStatus.ERROR,
-                    PipelineStatus.STOPPED,
-                ]:
-                    raise ComputeHealthCheckException(
-                        f"Session in terminal state: {status.value}. Message: {session_response.session_message}",
-                        session_endpoint=compute_config.session_endpoint,
-                        last_status=status.value,
-                    )
-                else:
-                    last_message = f"Session status: {status.value}"
-                    log.debug(f"Unknown session status, continuing to wait: {last_message}")
-                    await asyncio.sleep(interval)
-                    continue
+                last_message = f"Health check returned status {response.status}"
+                await asyncio.sleep(interval)
+                continue
 
         except ComputeHealthCheckException:
             raise
         except aiohttp.ClientResponseError as e:
             last_message = f"HTTP {e.status}: {e.message}"
-            log.debug(f"HTTP error during health check: {last_message}")
+            log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
         except Exception as e:
             last_message = str(e)
-            log.debug(f"Exception during health check: {last_message}")
+            log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
 
         await asyncio.sleep(interval)
 

--- a/eyepop/compute/status.py
+++ b/eyepop/compute/status.py
@@ -3,10 +3,13 @@ import logging
 
 import aiohttp
 
-from eyepop.compute.context import ComputeContext
+from eyepop.compute.context import ComputeContext, PipelineStatus
+from eyepop.compute.responses import ComputeApiSessionResponse
 from eyepop.exceptions import ComputeHealthCheckException
 
 log = logging.getLogger("eyepop.compute")
+
+_TERMINAL_STATES = {PipelineStatus.FAILED, PipelineStatus.ERROR, PipelineStatus.STOPPED}
 
 
 async def wait_for_session(
@@ -39,25 +42,40 @@ async def wait_for_session(
         attempt += 1
         try:
             async with client_session.get(health_url, headers=headers) as response:
-                log.debug(f"GET /health - status: {response.status} (attempt {attempt})")
+                if response.status != 200:
+                    last_message = f"HTTP {response.status}"
+                    log.debug(f"GET /health - status: {response.status} (attempt {attempt})")
+                    await asyncio.sleep(interval)
+                    continue
 
-                if response.status == 200:
+                session_response = ComputeApiSessionResponse(**(await response.json()))
+                status = session_response.session_status
+                log.debug(f"GET /health - status: 200, pipeline: {status.value} (attempt {attempt})")
+
+                if status == PipelineStatus.RUNNING:
                     return True
 
-                last_message = f"Health check returned status {response.status}"
+                if status in _TERMINAL_STATES:
+                    raise ComputeHealthCheckException(
+                        f"Session in terminal state: {status.value}. "
+                        f"Message: {session_response.session_message}",
+                        session_endpoint=compute_config.session_endpoint,
+                        last_status=status.value,
+                    )
+
+                last_message = f"Pipeline status: {status.value}"
                 await asyncio.sleep(interval)
-                continue
 
         except ComputeHealthCheckException:
             raise
         except aiohttp.ClientResponseError as e:
             last_message = f"HTTP {e.status}: {e.message}"
             log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
+            await asyncio.sleep(interval)
         except Exception as e:
             last_message = str(e)
             log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
-
-        await asyncio.sleep(interval)
+            await asyncio.sleep(interval)
 
     log.error(f"Session timed out after {timeout}s. Last message: {last_message}")
     raise TimeoutError(f"Session timed out after {timeout}s. Last message: {last_message}")

--- a/eyepop/compute/status.py
+++ b/eyepop/compute/status.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 import aiohttp
+from pydantic import ValidationError
 
 from eyepop.compute.context import ComputeContext, PipelineStatus
 from eyepop.compute.responses import ComputeApiSessionResponse
@@ -48,7 +49,14 @@ async def wait_for_session(
                     await asyncio.sleep(interval)
                     continue
 
-                session_response = ComputeApiSessionResponse(**(await response.json()))
+                body = await response.json()
+
+                try:
+                    session_response = ComputeApiSessionResponse(**body)
+                except ValidationError:
+                    log.debug(f"GET /health - status: 200, simple health response (attempt {attempt})")
+                    return True
+
                 status = session_response.session_status
                 log.debug(f"GET /health - status: 200, pipeline: {status.value} (attempt {attempt})")
 

--- a/eyepop/compute/status.py
+++ b/eyepop/compute/status.py
@@ -53,9 +53,14 @@ async def wait_for_session(
 
                 try:
                     session_response = ComputeApiSessionResponse(**body)
-                except ValidationError:
-                    log.debug(f"GET /health - status: 200, simple health response (attempt {attempt})")
-                    return True
+                except ValidationError as e:
+                    if isinstance(body, dict) and "message" in body and "session_status" not in body:
+                        log.debug(f"GET /health - status: 200, simple health response (attempt {attempt})")
+                        return True
+                    last_message = f"Invalid health payload: {e}"
+                    log.debug(f"GET /health - {last_message} (attempt {attempt})")
+                    await asyncio.sleep(interval)
+                    continue
 
                 status = session_response.session_status
                 log.debug(f"GET /health - status: 200, pipeline: {status.value} (attempt {attempt})")

--- a/eyepop/endpoint.py
+++ b/eyepop/endpoint.py
@@ -215,7 +215,6 @@ class Endpoint(ClientSession):
             if self.compute_ctx.m2m_access_token:
                 return self.compute_ctx.m2m_access_token
             else:
-                log.debug("compute ctx m2m access token is None, fetching new token")
                 assert self.client_session is not None
                 authenticate_url = f'{self.compute_ctx.compute_url}/v1/auth/authenticate'
                 api_auth_header = {
@@ -224,9 +223,9 @@ class Endpoint(ClientSession):
                     'Accept': 'application/json'
                 }
                 async with self.client_session.post(authenticate_url, headers=api_auth_header) as response:
+                    log.debug(f"POST /v1/auth/authenticate - status: {response.status}")
                     response_json = await response.json()
                     self.compute_ctx.m2m_access_token = response_json['access_token']
-                    log.debug(f"compute ctx m2m access token: {self.compute_ctx.m2m_access_token}")
                     return self.compute_ctx.m2m_access_token
         if self.secret_key is None:
             return None

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -193,7 +193,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 raise e
 
         if self.compute_ctx:
-            log_requests.debug(f'Using compute context config: {self.worker_config}')
+            log_requests.debug(f'Compute session: {self.compute_ctx.session_uuid}')
 
         base_url = await self.dev_mode_base_url()
 

--- a/tests/integration/test_worker_endpoint.py
+++ b/tests/integration/test_worker_endpoint.py
@@ -10,12 +10,36 @@ TEST_POP = Pop(components=[
     InferenceComponent(ability="eyepop.person:latest")
 ])
 
+# test.jpg is 480x640, model should detect at least 10 persons
+EXPECTED_SOURCE_WIDTH = 480
+EXPECTED_SOURCE_HEIGHT = 640
+MIN_EXPECTED_PERSONS = 10
+MIN_CONFIDENCE = 0.5
+
 
 def requires_api_key():
     return pytest.mark.skipif(
         not os.getenv("EYEPOP_API_KEY"),
         reason="EYEPOP_API_KEY environment variable not set",
     )
+
+
+def assert_person_detection_result(result: dict):
+    assert result["source_width"] == EXPECTED_SOURCE_WIDTH
+    assert result["source_height"] == EXPECTED_SOURCE_HEIGHT
+
+    objects = result.get("objects", [])
+    assert len(objects) >= MIN_EXPECTED_PERSONS, (
+        f"Expected at least {MIN_EXPECTED_PERSONS} persons, got {len(objects)}"
+    )
+
+    for obj in objects:
+        assert obj["classLabel"] == "person"
+        assert obj["confidence"] >= MIN_CONFIDENCE
+        assert obj["width"] > 0
+        assert obj["height"] > 0
+        assert obj["x"] >= 0
+        assert obj["y"] >= 0
 
 
 @requires_api_key()
@@ -26,17 +50,7 @@ def test_transient_pop_load_from_url():
         job = endpoint.load_from(PUBLIC_TEST_IMAGE_URL)
         result = job.predict()
 
-        print("\n=== Inference Result (sync) ===")
-        print(f"Source: {result.get('source_width')}x{result.get('source_height')}")
-        print(f"Objects detected: {len(result.get('objects', []))}")
-        for obj in result.get("objects", []):
-            print(f"  - {obj.get('classLabel')} (confidence: {obj.get('confidence', 0):.2f})")
-
-        assert result is not None
-        assert "source_width" in result
-        assert "source_height" in result
-        assert result["source_width"] > 0
-        assert result["source_height"] > 0
+        assert_person_detection_result(result)
 
 
 @requires_api_key()
@@ -48,17 +62,7 @@ async def test_transient_pop_load_from_url_async():
         job = await endpoint.load_from(PUBLIC_TEST_IMAGE_URL)
         result = await job.predict()
 
-        print("\n=== Inference Result (async) ===")
-        print(f"Source: {result.get('source_width')}x{result.get('source_height')}")
-        print(f"Objects detected: {len(result.get('objects', []))}")
-        for obj in result.get("objects", []):
-            print(f"  - {obj.get('classLabel')} (confidence: {obj.get('confidence', 0):.2f})")
-
-        assert result is not None
-        assert "source_width" in result
-        assert "source_height" in result
-        assert result["source_width"] > 0
-        assert result["source_height"] > 0
+        assert_person_detection_result(result)
 
 
 @requires_api_key()

--- a/tests/integration/test_worker_endpoint.py
+++ b/tests/integration/test_worker_endpoint.py
@@ -28,7 +28,7 @@ def assert_person_detection_result(result: dict):
     assert result["source_width"] == EXPECTED_SOURCE_WIDTH
     assert result["source_height"] == EXPECTED_SOURCE_HEIGHT
 
-    objects = result.get("objects", [])
+    objects = result.get("objects") or []
     assert len(objects) >= MIN_EXPECTED_PERSONS, (
         f"Expected at least {MIN_EXPECTED_PERSONS} persons, got {len(objects)}"
     )

--- a/tests/test_compute_status.py
+++ b/tests/test_compute_status.py
@@ -1,0 +1,125 @@
+import aiohttp
+import pytest
+
+from eyepop.compute.context import ComputeContext, PipelineStatus
+from eyepop.compute.status import wait_for_session
+from eyepop.exceptions import ComputeHealthCheckException
+
+HEALTH_URL = "https://session.example.com/health"
+
+
+def _config(**overrides) -> ComputeContext:
+    defaults = dict(
+        session_endpoint="https://session.example.com",
+        m2m_access_token="jwt-123",
+        wait_for_session_timeout=5,
+        wait_for_session_interval=1,
+    )
+    return ComputeContext(**(defaults | overrides))
+
+
+@pytest.mark.asyncio
+async def test_returns_true_on_running_pipeline(aioresponses):
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "running",
+    })
+
+    async with aiohttp.ClientSession() as session:
+        assert await wait_for_session(_config(), session) is True
+
+
+@pytest.mark.asyncio
+async def test_returns_true_on_simple_health_response(aioresponses):
+    """Health endpoint can return {"message": "I'm fine"} without session fields."""
+    aioresponses.get(HEALTH_URL, payload={"message": "I'm fine"})
+
+    async with aiohttp.ClientSession() as session:
+        assert await wait_for_session(_config(), session) is True
+
+
+@pytest.mark.asyncio
+async def test_raises_on_terminal_state(aioresponses):
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "failed",
+        "session_message": "OOM killed",
+    })
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ComputeHealthCheckException, match="terminal state"):
+            await wait_for_session(_config(), session)
+
+
+@pytest.mark.asyncio
+async def test_retries_on_pending_then_succeeds(aioresponses):
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "pending",
+    })
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "running",
+    })
+
+    async with aiohttp.ClientSession() as session:
+        assert await wait_for_session(_config(), session) is True
+
+
+@pytest.mark.asyncio
+async def test_retries_on_non_200_then_succeeds(aioresponses):
+    aioresponses.get(HEALTH_URL, status=503)
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "running",
+    })
+
+    async with aiohttp.ClientSession() as session:
+        assert await wait_for_session(_config(), session) is True
+
+
+@pytest.mark.asyncio
+async def test_times_out_when_never_ready(aioresponses):
+    for _ in range(100):
+        aioresponses.get(HEALTH_URL, status=503)
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(TimeoutError, match="timed out"):
+            await wait_for_session(_config(wait_for_session_timeout=1), session)
+
+
+@pytest.mark.asyncio
+async def test_raises_without_access_token():
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ComputeHealthCheckException, match="No access_token"):
+            await wait_for_session(_config(m2m_access_token=""), session)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", [
+    PipelineStatus.FAILED,
+    PipelineStatus.ERROR,
+    PipelineStatus.STOPPED,
+])
+async def test_raises_on_all_terminal_states(aioresponses, terminal_status):
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": terminal_status.value,
+        "session_message": "bad",
+    })
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ComputeHealthCheckException, match="terminal state"):
+            await wait_for_session(_config(), session)


### PR DESCRIPTION
## Summary
- Health check (`wait_for_session`) parses pipeline status on 200 responses, handles responses without pipeline status, narrows ValidationError fallback
- Adds unit tests for `wait_for_session` (`tests/test_compute_status.py`)
- Cleans up debug logging across `compute/api.py`, `compute/status.py`, `endpoint.py`, `worker_endpoint.py`: consistent format, removes credential leaks

## Test plan
- [x] `task check` (lint + typecheck + test) — 124 passed
- [ ] Smoke session creation against staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Health check improvements**: Session readiness now correctly parses pipeline status, treating RUNNING as success and terminal states (FAILED, ERROR, STOPPED) as immediate failures, while properly handling simple 200 responses lacking session fields.

- **Robust health check validation**: Narrowed the error fallback logic so only payloads with a `message` field and no `session_status` are treated as simple health responses, while other schema mismatches are retried with logged errors.

- **New health check test suite**: Added comprehensive unit tests covering running/pending/terminal states, simple health responses, non-200 retries, timeouts, and missing access tokens.

- **Debug logging cleanup**: Unified logging format across the codebase to "METHOD /path - status: N", removed verbose per-branch logs and redundant health-check noise, and eliminated unsafe logging of raw access tokens and full token responses.

- **Config logging improvements**: Replaced verbose full config dumps with session UUID logging for better readability and security.

- **Improved integration tests**: Enhanced inference validation with shared assertion routine that validates expected dimensions, minimum object counts, and confidence thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->