### PR TITLE
[AWSU-166] Isolate ephemeral SDK connections from persistent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)
+
 ## [3.15.2] - 2026-04-27
 
 ### Added

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -61,10 +61,13 @@ async def fetch_new_compute_session(
 
                 if not res:
                     need_new_session = True
-                elif isinstance(res, list) and len(res) == 0:
-                    need_new_session = True
-                elif isinstance(res, dict) and not res.get("session_uuid"):
-                    need_new_session = True
+                elif isinstance(res, list):
+                    res = [s for s in res if isinstance(s, dict) and not s.get("persistent")]
+                    if not res:
+                        need_new_session = True
+                elif isinstance(res, dict):
+                    if not res.get("session_uuid") or res.get("persistent"):
+                        need_new_session = True
 
     except aiohttp.ClientResponseError as e:
         if e.status == 404:

--- a/eyepop/compute/responses.py
+++ b/eyepop/compute/responses.py
@@ -44,6 +44,6 @@ class ComputeApiSessionResponse(BaseModel):
     pipeline_ttl: int | None = Field(description="The ttl of the pipeline", default=None)
     session_active: bool = Field(description="Whether the session is active", default=False)
     persistent: bool = Field(
-        description="Whether the session is persistent (static). Ephemeral when False.",
+        description="Whether the session is persistent. Ephemeral when False.",
         default=False,
     )

--- a/eyepop/compute/responses.py
+++ b/eyepop/compute/responses.py
@@ -43,3 +43,7 @@ class ComputeApiSessionResponse(BaseModel):
     )
     pipeline_ttl: int | None = Field(description="The ttl of the pipeline", default=None)
     session_active: bool = Field(description="Whether the session is active", default=False)
+    persistent: bool = Field(
+        description="Whether the session is persistent (static). Ephemeral when False.",
+        default=False,
+    )

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -358,3 +358,19 @@ async def test_creates_new_session_when_single_dict_is_persistent(mock_compute_c
         result = await fetch_new_compute_session(mock_compute_config, session)
 
     assert result.session_uuid == "ephemeral-456"
+
+
+@pytest.mark.asyncio
+async def test_adopts_single_dict_ephemeral_session(mock_compute_config, aioresponses):
+    """GET returns single ephemeral dict → SDK adopts it without POST."""
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=EPHEMERAL_SESSION_RESPONSE,
+        status=200,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(mock_compute_config, session)
+
+    assert result.session_uuid == "ephemeral-456"
+    assert result.session_endpoint == "https://ephemeral.example.com"

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -286,3 +286,75 @@ async def test_creates_session_without_pipeline_image(aioresponses):
         result = await fetch_new_compute_session(ctx, session)
 
     assert result.session_endpoint == "https://pipeline.example.com"
+
+
+PERSISTENT_SESSION_RESPONSE = {
+    **MOCK_SESSION_RESPONSE,
+    "session_uuid": "persistent-999",
+    "session_endpoint": "https://persistent.example.com",
+    "persistent": True,
+}
+
+EPHEMERAL_SESSION_RESPONSE = {
+    **MOCK_SESSION_RESPONSE,
+    "session_uuid": "ephemeral-456",
+    "session_endpoint": "https://ephemeral.example.com",
+    "persistent": False,
+}
+
+
+@pytest.mark.asyncio
+async def test_skips_persistent_session_in_mixed_list(mock_compute_config, aioresponses):
+    """No session_uuid passed: SDK must ignore persistent sessions and pick ephemeral."""
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[PERSISTENT_SESSION_RESPONSE, EPHEMERAL_SESSION_RESPONSE],
+        status=200,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(mock_compute_config, session)
+
+    assert result.session_uuid == "ephemeral-456"
+    assert result.session_endpoint == "https://ephemeral.example.com"
+
+
+@pytest.mark.asyncio
+async def test_creates_new_session_when_only_persistent_exist(mock_compute_config, aioresponses):
+    """All existing sessions are persistent → POST a fresh ephemeral session."""
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[PERSISTENT_SESSION_RESPONSE],
+        status=200,
+    )
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        payload=EPHEMERAL_SESSION_RESPONSE,
+        status=200,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(mock_compute_config, session)
+
+    assert result.session_uuid == "ephemeral-456"
+    assert result.session_endpoint == "https://ephemeral.example.com"
+
+
+@pytest.mark.asyncio
+async def test_creates_new_session_when_single_dict_is_persistent(mock_compute_config, aioresponses):
+    """GET returns a single persistent dict → SDK must not adopt it; POST instead."""
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=PERSISTENT_SESSION_RESPONSE,
+        status=200,
+    )
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        payload=EPHEMERAL_SESSION_RESPONSE,
+        status=200,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(mock_compute_config, session)
+
+    assert result.session_uuid == "ephemeral-456"


### PR DESCRIPTION
## Summary

Without a `session_uuid` argument, the SDK was silently adopting whichever session sat at index 0 of `GET /v1/sessions`. That endpoint returns the user's full session list — ephemeral and persistent both — so a user with a static session got reconnected to it via the ephemeral code path.

This PR isolates the two modes on the SDK side. Compute API behavior is unchanged.

## What changed

- `eyepop/compute/responses.py` — added `persistent: bool = False` to `ComputeApiSessionResponse` so the SDK can read the flag.
- `eyepop/compute/api.py::fetch_new_compute_session` — filter `GET /v1/sessions` results to drop `persistent: true` entries before picking. If only persistent sessions exist (or the single dict response is persistent), fall through to `POST /v1/sessions`, which the compute API only mints persistent for when `req.persistent=true` (the SDK never sets that).
- `tests/test_compute_api.py` — three new tests: mixed list picks ephemeral; all-persistent list triggers POST; single persistent dict triggers POST.
- `CHANGELOG.md` — Unreleased entry.

Persistent sessions remain reachable via `fetch_permanent_compute_session` when `session_uuid` is passed explicitly. That path was already correct.

## Compute-API contract verified

- `GET /v1/sessions` (`api/v1/sessions/get_eyepopsession.go`) → `ListEyePopSessions(userUUID)` (`internal/eyepopsession/service_impl.go:177`) builds `EyePopSessionContext{UserUuid: userUUID}` only.
- `manager/list.go:47` only applies the `LabelPersistent` selector when `sessionContext.Persistent == true`. Default listing returns both types.
- `convertToUserResponse` maps `session.Spec.Persistent → response.Persistent`.
- `pkg.EyePopSessionResponse.Persistent bool \`json:"persistent"\`` — no `omitempty`, always serialized.
- Redis cache uses plain `json.Marshal` so the flag survives round-trip.

## Test plan

- [x] `task check` (lint + typecheck + tests) — green, 117 passed
- [ ] Smoke test against staging with a user that has a persistent session — verify ephemeral SDK call POSTs a new session instead of adopting the persistent one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worker connection behavior to prevent ephemeral connections from incorrectly adopting persistent sessions.
  * Compute API now properly constrains session selection via persistence flag.
  * Ephemeral connections always use or create ephemeral sessions; persistent sessions only accessible when UUID is explicitly passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->