### PR TITLE
[OPA-38] Support InferenceComponent.objectAreaThreshold to filter based on object areas relative to the input image dimension

### DIFF
--- a/eyepop/worker/worker_types.py
+++ b/eyepop/worker/worker_types.py
@@ -87,6 +87,7 @@ class InferenceComponent(BaseComponent):
     ability: str | None = None
     categoryName: str | None = None
     confidenceThreshold: float | None = None
+    objectAreaThreshold: float | None = None
     topK: int | None = None
     topKClasses: int | None = None
     targetFps: str | None = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional object area threshold configuration parameter for inference operations, allowing users to fine-tune detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->