### PR TITLE
[SDK]: Add sessions smoke workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,8 @@ name: Checks and tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,29 +1,22 @@
-name: Integration Tests
+name: Staging SDK Integration
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to test against'
-        required: true
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
   schedule:
     - cron: '0 6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-staging
   cancel-in-progress: true
 
 jobs:
   integration:
+    name: staging integration
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: staging
     env:
-      EYEPOP_URL: https://compute.staging.eyepop.xyz
+      EYEPOP_URL: ${{ vars.EYEPOP_URL }}
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -37,14 +37,14 @@ jobs:
       TARGET_ENV: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
       SDK_VERSION: ${{ github.event_name == 'schedule' && 'latest' || inputs.sdk_version }}
       EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}-${{ github.run_id }}-${{ github.run_attempt }}
-      EYEPOP_API_KEY: ${{ secrets.EYEPOP_API_KEY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SUMMARY_JSON: session-smoke-summary.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
 
       - name: Install SDK under test
         run: |
@@ -62,6 +62,8 @@ jobs:
 
       - name: Run SDK session smoke
         id: smoke
+        env:
+          EYEPOP_API_KEY: ${{ secrets.EYEPOP_API_KEY }}
         run: |
           set -euo pipefail
           if [[ "$SDK_VERSION" == "source" ]]; then
@@ -107,7 +109,7 @@ jobs:
 
       - name: Upload smoke summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sessions-smoke-summary-${{ env.TARGET_ENV }}
           path: ${{ env.SUMMARY_JSON }}
@@ -116,6 +118,7 @@ jobs:
       - name: Notify Slack
         if: always()
         env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SMOKE_CONCLUSION: ${{ steps.smoke.conclusion }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -191,7 +194,17 @@ jobs:
               ]
             }' > slack-payload.json
 
-          curl -sS -X POST \
-            -H "Content-Type: application/json" \
-            --data @slack-payload.json \
-            "$SLACK_WEBHOOK_URL"
+          for attempt in 1 2 3; do
+            if curl --fail-with-body -sS -X POST \
+              -H "Content-Type: application/json" \
+              --data @slack-payload.json \
+              "$SLACK_WEBHOOK_URL"; then
+              exit 0
+            fi
+
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -1,9 +1,6 @@
 name: Sessions Smoke
 
 on:
-  push:
-    branches:
-      - codex/session-smoke-workflow
   schedule:
     # 07:30 and 14:30 America/Los_Angeles while daylight saving time is in effect.
     - cron: "30 14,21 * * *"
@@ -117,7 +114,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Notify Slack
-        if: always()
+        if: ${{ failure() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SMOKE_CONCLUSION: ${{ steps.smoke.conclusion }}
@@ -130,7 +127,6 @@ jobs:
             exit 0
           fi
 
-          ok="false"
           session_uuid="n/a"
           session_name="n/a"
           predictions="n/a"
@@ -138,10 +134,9 @@ jobs:
           cleanup="n/a"
           duration="n/a"
           actual_sdk="n/a"
-          error=""
+          reason="Smoke workflow failed before a JSON summary was captured."
 
           if [[ -f "$SUMMARY_JSON" ]] && jq -e . "$SUMMARY_JSON" >/dev/null 2>&1; then
-            ok="$(jq -r '(.ok // false)|tostring' "$SUMMARY_JSON")"
             actual_sdk="$(jq -r '.sdk_version // "n/a"' "$SUMMARY_JSON")"
             session_name="$(jq -r '.session_name // "n/a"' "$SUMMARY_JSON")"
             session_uuid="$(jq -r '.session_uuid_short // "n/a"' "$SUMMARY_JSON")"
@@ -149,9 +144,13 @@ jobs:
             matching_objects="$(jq -r '(.matching_object_count // "n/a")|tostring' "$SUMMARY_JSON")"
             cleanup="$(jq -r '.cleanup.result // "n/a"' "$SUMMARY_JSON")"
             duration="$(jq -r '(.duration_seconds // "n/a")|tostring' "$SUMMARY_JSON")"
-            error="$(jq -r '.error // ""' "$SUMMARY_JSON")"
+            reason="$(jq -r '.error // ""' "$SUMMARY_JSON")"
           else
-            error="No JSON summary captured"
+            reason="No JSON summary captured."
+          fi
+
+          if [[ -z "$reason" ]]; then
+            reason="Smoke step concluded with ${SMOKE_CONCLUSION}."
           fi
 
           title="Production sessions smoke"
@@ -159,22 +158,22 @@ jobs:
             title="${SMOKE_ENVIRONMENT^} sessions smoke"
           fi
 
-          status="passed"
-          if [[ "$SMOKE_CONCLUSION" != "success" || "$ok" != "true" ]]; then
-            status="failed"
-          fi
-
-          text="$title $status"
-          details="*Environment:* $SMOKE_ENVIRONMENT\n*SDK:* $actual_sdk (requested: $SDK_VERSION)\n*Run:* <$RUN_URL|GitHub Actions>\n*Session name:* $session_name\n*Session:* $session_uuid\n*Predictions:* $predictions\n*Matching objects:* $matching_objects\n*Cleanup:* $cleanup\n*Duration:* ${duration}s"
-          if [[ -n "$error" ]]; then
-            details="$details\n*Error:* $error"
-          fi
+          text="$title failed: $reason"
 
           jq -n \
             --arg text "$text" \
             --arg title "$title" \
-            --arg status "$status" \
-            --arg details "$details" \
+            --arg reason "$reason" \
+            --arg environment "$SMOKE_ENVIRONMENT" \
+            --arg requested_sdk "$SDK_VERSION" \
+            --arg actual_sdk "$actual_sdk" \
+            --arg session_name "$session_name" \
+            --arg session_uuid "$session_uuid" \
+            --arg predictions "$predictions" \
+            --arg matching_objects "$matching_objects" \
+            --arg cleanup "$cleanup" \
+            --arg duration "$duration" \
+            --arg run_url "$RUN_URL" \
             '{
               text: $text,
               blocks: [
@@ -182,15 +181,38 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: ("*" + $title + " " + $status + "*")
+                    text: ("*" + $title + " failed*")
                   }
                 },
                 {
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: $details
+                    text: ("*Reason:* " + $reason)
                   }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    {type: "mrkdwn", text: ("*Environment:*\n" + $environment)},
+                    {type: "mrkdwn", text: ("*SDK:*\n" + $actual_sdk + " (requested: " + $requested_sdk + ")")},
+                    {type: "mrkdwn", text: ("*Session name:*\n" + $session_name)},
+                    {type: "mrkdwn", text: ("*Session:*\n" + $session_uuid)},
+                    {type: "mrkdwn", text: ("*Predictions:*\n" + $predictions)},
+                    {type: "mrkdwn", text: ("*Matching objects:*\n" + $matching_objects)},
+                    {type: "mrkdwn", text: ("*Cleanup:*\n" + $cleanup)},
+                    {type: "mrkdwn", text: ("*Duration:*\n" + $duration + "s")}
+                  ]
+                },
+                {
+                  type: "actions",
+                  elements: [
+                    {
+                      type: "button",
+                      text: {type: "plain_text", text: "Open GitHub run"},
+                      url: $run_url
+                    }
+                  ]
                 }
               ]
             }' > slack-payload.json

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -1,0 +1,193 @@
+name: Sessions Smoke
+
+on:
+  schedule:
+    # 07:30 and 14:30 America/Los_Angeles while daylight saving time is in effect.
+    - cron: "30 14,21 * * *"
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: Environment to smoke
+        required: true
+        default: production
+        type: choice
+        options:
+          - staging
+          - production
+      sdk_version:
+        description: "SDK package to test: latest, source, or an exact version like 3.2.1"
+        required: true
+        default: latest
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  session-smoke:
+    name: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }} transient session
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
+    env:
+      TARGET_ENV: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
+      SDK_VERSION: ${{ github.event_name == 'schedule' && 'latest' || inputs.sdk_version }}
+      EYEPOP_API_KEY: ${{ secrets.EYEPOP_API_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SUMMARY_JSON: session-smoke-summary.json
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install SDK under test
+        run: |
+          set -euo pipefail
+          if [[ "$SDK_VERSION" == "source" ]]; then
+            uv sync --locked --all-extras --dev
+          else
+            uv venv
+            if [[ "$SDK_VERSION" == "latest" ]]; then
+              uv pip install --upgrade eyepop
+            else
+              uv pip install "eyepop==$SDK_VERSION"
+            fi
+          fi
+
+      - name: Run SDK session smoke
+        id: smoke
+        run: |
+          set -euo pipefail
+          if [[ "$SDK_VERSION" == "source" ]]; then
+            uv run python scripts/session_smoke.py \
+              --environment "$TARGET_ENV" \
+              --image tests/test.jpg \
+              --summary-json "$SUMMARY_JSON"
+          else
+            cd "$RUNNER_TEMP"
+            "$GITHUB_WORKSPACE/.venv/bin/python" "$GITHUB_WORKSPACE/scripts/session_smoke.py" \
+              --environment "$TARGET_ENV" \
+              --image "$GITHUB_WORKSPACE/tests/test.jpg" \
+              --summary-json "$GITHUB_WORKSPACE/$SUMMARY_JSON"
+          fi
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Sessions Smoke"
+            echo ""
+            echo "- environment: $TARGET_ENV"
+            echo "- requested_sdk: $SDK_VERSION"
+            echo "- conclusion: ${{ steps.smoke.conclusion }}"
+            echo "- run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            if [[ -f "$SUMMARY_JSON" ]] && jq -e . "$SUMMARY_JSON" >/dev/null 2>&1; then
+              jq -r '
+                "- ok: \((.ok // false)|tostring)",
+                "- sdk_version: \(.sdk_version // "n/a")",
+                "- session_uuid: \(.session_uuid_short // "n/a")",
+                "- ability: \(.ability // "n/a")",
+                "- predictions: \((.prediction_count // "n/a")|tostring)",
+                "- matching_objects: \((.matching_object_count // "n/a")|tostring)",
+                "- cleanup: \(.cleanup.result // "n/a")",
+                "- duration_seconds: \((.duration_seconds // "n/a")|tostring)",
+                if .error then "- error: \(.error)" else empty end
+              ' "$SUMMARY_JSON"
+            else
+              echo "- result: no JSON summary captured"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload smoke summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sessions-smoke-summary-${{ env.TARGET_ENV }}
+          path: ${{ env.SUMMARY_JSON }}
+          if-no-files-found: ignore
+
+      - name: Notify Slack
+        if: always()
+        env:
+          SMOKE_CONCLUSION: ${{ steps.smoke.conclusion }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
+            echo "SLACK_WEBHOOK_URL not set; skipping Slack notification"
+            exit 0
+          fi
+
+          ok="false"
+          session_uuid="n/a"
+          predictions="n/a"
+          matching_objects="n/a"
+          cleanup="n/a"
+          duration="n/a"
+          actual_sdk="n/a"
+          error=""
+
+          if [[ -f "$SUMMARY_JSON" ]] && jq -e . "$SUMMARY_JSON" >/dev/null 2>&1; then
+            ok="$(jq -r '(.ok // false)|tostring' "$SUMMARY_JSON")"
+            actual_sdk="$(jq -r '.sdk_version // "n/a"' "$SUMMARY_JSON")"
+            session_uuid="$(jq -r '.session_uuid_short // "n/a"' "$SUMMARY_JSON")"
+            predictions="$(jq -r '(.prediction_count // "n/a")|tostring' "$SUMMARY_JSON")"
+            matching_objects="$(jq -r '(.matching_object_count // "n/a")|tostring' "$SUMMARY_JSON")"
+            cleanup="$(jq -r '.cleanup.result // "n/a"' "$SUMMARY_JSON")"
+            duration="$(jq -r '(.duration_seconds // "n/a")|tostring' "$SUMMARY_JSON")"
+            error="$(jq -r '.error // ""' "$SUMMARY_JSON")"
+          else
+            error="No JSON summary captured"
+          fi
+
+          title="Production sessions smoke"
+          if [[ "$TARGET_ENV" != "production" ]]; then
+            title="${TARGET_ENV^} sessions smoke"
+          fi
+
+          status="passed"
+          if [[ "$SMOKE_CONCLUSION" != "success" || "$ok" != "true" ]]; then
+            status="failed"
+          fi
+
+          text="$title $status"
+          details="*Environment:* $TARGET_ENV\n*SDK:* $actual_sdk (requested: $SDK_VERSION)\n*Run:* <$RUN_URL|GitHub Actions>\n*Session:* $session_uuid\n*Predictions:* $predictions\n*Matching objects:* $matching_objects\n*Cleanup:* $cleanup\n*Duration:* ${duration}s"
+          if [[ -n "$error" ]]; then
+            details="$details\n*Error:* $error"
+          fi
+
+          jq -n \
+            --arg text "$text" \
+            --arg title "$title" \
+            --arg status "$status" \
+            --arg details "$details" \
+            '{
+              text: $text,
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ("*" + $title + " " + $status + "*")
+                  }
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: $details
+                  }
+                }
+              ]
+            }' > slack-payload.json
+
+          curl -sS -X POST \
+            -H "Content-Type: application/json" \
+            --data @slack-payload.json \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -37,6 +37,7 @@ jobs:
       SMOKE_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
       SDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_version || github.event_name == 'schedule' && 'latest' || 'source' }}
       EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}-${{ github.run_id }}-${{ github.run_attempt }}
+      EYEPOP_URL: ${{ vars.EYEPOP_URL }}
       SUMMARY_JSON: session-smoke-summary.json
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -9,14 +9,11 @@ on:
     - cron: "30 14,21 * * *"
   workflow_dispatch:
     inputs:
-      target_env:
+      environment:
         description: Environment to smoke
         required: true
         default: production
-        type: choice
-        options:
-          - staging
-          - production
+        type: environment
       sdk_version:
         description: "SDK package to test: latest, source, or an exact version like 3.2.1"
         required: true
@@ -24,7 +21,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
   cancel-in-progress: true
 
 permissions:
@@ -32,14 +29,14 @@ permissions:
 
 jobs:
   session-smoke:
-    name: ${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }} transient session
+    name: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }} transient session
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
     env:
-      TARGET_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}
+      SMOKE_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
       SDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_version || github.event_name == 'schedule' && 'latest' || 'source' }}
-      EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}-${{ github.run_id }}-${{ github.run_attempt }}
+      EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}-${{ github.run_id }}-${{ github.run_attempt }}
       SUMMARY_JSON: session-smoke-summary.json
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -71,13 +68,13 @@ jobs:
           set -euo pipefail
           if [[ "$SDK_VERSION" == "source" ]]; then
             uv run python scripts/session_smoke.py \
-              --environment "$TARGET_ENV" \
+              --environment "$SMOKE_ENVIRONMENT" \
               --image tests/test.jpg \
               --summary-json "$SUMMARY_JSON"
           else
             cd "$RUNNER_TEMP"
             "$GITHUB_WORKSPACE/.venv/bin/python" "$GITHUB_WORKSPACE/scripts/session_smoke.py" \
-              --environment "$TARGET_ENV" \
+              --environment "$SMOKE_ENVIRONMENT" \
               --image "$GITHUB_WORKSPACE/tests/test.jpg" \
               --summary-json "$GITHUB_WORKSPACE/$SUMMARY_JSON"
           fi
@@ -88,7 +85,7 @@ jobs:
           {
             echo "## Sessions Smoke"
             echo ""
-            echo "- environment: $TARGET_ENV"
+            echo "- environment: $SMOKE_ENVIRONMENT"
             echo "- requested_sdk: $SDK_VERSION"
             echo "- conclusion: ${{ steps.smoke.conclusion }}"
             echo "- run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -114,7 +111,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: sessions-smoke-summary-${{ env.TARGET_ENV }}
+          name: sessions-smoke-summary-${{ env.SMOKE_ENVIRONMENT }}
           path: ${{ env.SUMMARY_JSON }}
           if-no-files-found: ignore
 
@@ -157,8 +154,8 @@ jobs:
           fi
 
           title="Production sessions smoke"
-          if [[ "$TARGET_ENV" != "production" ]]; then
-            title="${TARGET_ENV^} sessions smoke"
+          if [[ "$SMOKE_ENVIRONMENT" != "production" ]]; then
+            title="${SMOKE_ENVIRONMENT^} sessions smoke"
           fi
 
           status="passed"
@@ -167,7 +164,7 @@ jobs:
           fi
 
           text="$title $status"
-          details="*Environment:* $TARGET_ENV\n*SDK:* $actual_sdk (requested: $SDK_VERSION)\n*Run:* <$RUN_URL|GitHub Actions>\n*Session name:* $session_name\n*Session:* $session_uuid\n*Predictions:* $predictions\n*Matching objects:* $matching_objects\n*Cleanup:* $cleanup\n*Duration:* ${duration}s"
+          details="*Environment:* $SMOKE_ENVIRONMENT\n*SDK:* $actual_sdk (requested: $SDK_VERSION)\n*Run:* <$RUN_URL|GitHub Actions>\n*Session name:* $session_name\n*Session:* $session_uuid\n*Predictions:* $predictions\n*Matching objects:* $matching_objects\n*Cleanup:* $cleanup\n*Duration:* ${duration}s"
           if [[ -n "$error" ]]; then
             details="$details\n*Error:* $error"
           fi

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -36,6 +36,7 @@ jobs:
     env:
       TARGET_ENV: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
       SDK_VERSION: ${{ github.event_name == 'schedule' && 'latest' || inputs.sdk_version }}
+      EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}-${{ github.run_id }}-${{ github.run_attempt }}
       EYEPOP_API_KEY: ${{ secrets.EYEPOP_API_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SUMMARY_JSON: session-smoke-summary.json
@@ -90,6 +91,7 @@ jobs:
               jq -r '
                 "- ok: \((.ok // false)|tostring)",
                 "- sdk_version: \(.sdk_version // "n/a")",
+                "- session_name: \(.session_name // "n/a")",
                 "- session_uuid: \(.session_uuid_short // "n/a")",
                 "- ability: \(.ability // "n/a")",
                 "- predictions: \((.prediction_count // "n/a")|tostring)",
@@ -126,6 +128,7 @@ jobs:
 
           ok="false"
           session_uuid="n/a"
+          session_name="n/a"
           predictions="n/a"
           matching_objects="n/a"
           cleanup="n/a"
@@ -136,6 +139,7 @@ jobs:
           if [[ -f "$SUMMARY_JSON" ]] && jq -e . "$SUMMARY_JSON" >/dev/null 2>&1; then
             ok="$(jq -r '(.ok // false)|tostring' "$SUMMARY_JSON")"
             actual_sdk="$(jq -r '.sdk_version // "n/a"' "$SUMMARY_JSON")"
+            session_name="$(jq -r '.session_name // "n/a"' "$SUMMARY_JSON")"
             session_uuid="$(jq -r '.session_uuid_short // "n/a"' "$SUMMARY_JSON")"
             predictions="$(jq -r '(.prediction_count // "n/a")|tostring' "$SUMMARY_JSON")"
             matching_objects="$(jq -r '(.matching_object_count // "n/a")|tostring' "$SUMMARY_JSON")"
@@ -157,7 +161,7 @@ jobs:
           fi
 
           text="$title $status"
-          details="*Environment:* $TARGET_ENV\n*SDK:* $actual_sdk (requested: $SDK_VERSION)\n*Run:* <$RUN_URL|GitHub Actions>\n*Session:* $session_uuid\n*Predictions:* $predictions\n*Matching objects:* $matching_objects\n*Cleanup:* $cleanup\n*Duration:* ${duration}s"
+          details="*Environment:* $TARGET_ENV\n*SDK:* $actual_sdk (requested: $SDK_VERSION)\n*Run:* <$RUN_URL|GitHub Actions>\n*Session name:* $session_name\n*Session:* $session_uuid\n*Predictions:* $predictions\n*Matching objects:* $matching_objects\n*Cleanup:* $cleanup\n*Duration:* ${duration}s"
           if [[ -n "$error" ]]; then
             details="$details\n*Error:* $error"
           fi

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -1,6 +1,9 @@
 name: Sessions Smoke
 
 on:
+  push:
+    branches:
+      - codex/session-smoke-workflow
   schedule:
     # 07:30 and 14:30 America/Los_Angeles while daylight saving time is in effect.
     - cron: "30 14,21 * * *"
@@ -21,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}
   cancel-in-progress: true
 
 permissions:
@@ -29,14 +32,14 @@ permissions:
 
 jobs:
   session-smoke:
-    name: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }} transient session
+    name: ${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }} transient session
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}
     env:
-      TARGET_ENV: ${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}
-      SDK_VERSION: ${{ github.event_name == 'schedule' && 'latest' || inputs.sdk_version }}
-      EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'schedule' && 'production' || inputs.target_env }}-${{ github.run_id }}-${{ github.run_attempt }}
+      TARGET_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}
+      SDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_version || github.event_name == 'schedule' && 'latest' || 'source' }}
+      EYEPOP_SESSION_NAME: smoke-${{ github.event_name == 'workflow_dispatch' && inputs.target_env || 'production' }}-${{ github.run_id }}-${{ github.run_attempt }}
       SUMMARY_JSON: session-smoke-summary.json
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Scheduled sessions smoke workflow for validating transient SDK inference against production with optional Slack status alerts and selectable SDK package versions.
+
 ### Fixed
 - Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Scheduled sessions smoke workflow for validating transient SDK inference against production with optional Slack status alerts and selectable SDK package versions.
+- `session_name` support on worker session creation, also configurable via `EYEPOP_SESSION_NAME`.
 
 ### Fixed
 - Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -127,6 +127,8 @@ def _compute_context_from_response(compute_ctx: ComputeContext, res: dict | None
 
     compute_ctx.session_endpoint = session_response.session_endpoint
     compute_ctx.session_uuid = session_response.session_uuid
+    if session_response.session_name:
+        compute_ctx.session_name = session_response.session_name
     compute_ctx.m2m_access_token = session_response.access_token
     compute_ctx.access_token_expires_at = session_response.access_token_expires_at
     compute_ctx.access_token_expires_in = session_response.access_token_expires_in

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -82,6 +82,8 @@ async def fetch_new_compute_session(
     if need_new_session:
         try:
             body = {}
+            if compute_ctx.session_name:
+                body["session_name"] = compute_ctx.session_name
             if compute_ctx.pipeline_image:
                 body["pipeline_image"] = compute_ctx.pipeline_image
             if compute_ctx.pipeline_version:

--- a/eyepop/compute/context.py
+++ b/eyepop/compute/context.py
@@ -17,6 +17,10 @@ class ComputeContext(BaseModel):
     )
     session_endpoint: str = Field(description="The endpoint of the session", default="")
     session_uuid: str = Field(description="The uuid of the session", default="")
+    session_name: str = Field(
+        description="The requested name of the session",
+        default_factory=lambda: os.getenv("EYEPOP_SESSION_NAME", "")
+    )
     pipeline_uuid: str = Field(description="The uuid of the pipeline", default="")
     pipeline_id: str = Field(description="The id of the pipeline", default="")
     user_uuid: str = Field(description="The uuid of the user", default=os.getenv("EYEPOP_USER_UUID", ""))
@@ -66,4 +70,3 @@ class PipelineStatus(str, Enum):
             elif "pending" in value_lower or "creat" in value_lower or "start" in value_lower:
                 return cls.PENDING
         return cls.UNKNOWN
-

--- a/eyepop/compute/responses.py
+++ b/eyepop/compute/responses.py
@@ -10,6 +10,7 @@ class ComputeApiPipelineStatus(BaseModel):
 
 class ComputeApiSessionRequest(BaseModel):
     account_uuid: str = Field(description="Required account uuid to create a session")
+    session_name: str = Field(description="Optional name to create a session", default="")
 
 
 class ComputeApiSessionResponse(BaseModel):

--- a/eyepop/eyepopsdk.py
+++ b/eyepop/eyepopsdk.py
@@ -33,6 +33,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            session_name: str | None = None,
     ) -> WorkerEndpoint | SyncWorkerEndpoint:
         if is_async:
             return EyePopSdk.async_worker(
@@ -50,6 +51,7 @@ class EyePopSdk:
                 dataset_uuid=dataset_uuid,
                 pipeline_image=pipeline_image,
                 pipeline_version=pipeline_version,
+                session_name=session_name,
             )
         else:
             return EyePopSdk.sync_worker(
@@ -67,6 +69,7 @@ class EyePopSdk:
                 dataset_uuid=dataset_uuid,
                 pipeline_image=pipeline_image,
                 pipeline_version=pipeline_version,
+                session_name=session_name,
             )
 
     @staticmethod
@@ -85,6 +88,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            session_name: str | None = None,
     ) -> SyncWorkerEndpoint:
         endpoint = EyePopSdk.async_worker(
             pop_id=pop_id,
@@ -101,6 +105,7 @@ class EyePopSdk:
             dataset_uuid=dataset_uuid,
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
+            session_name=session_name,
         )
         return SyncWorkerEndpoint(endpoint)
 
@@ -120,6 +125,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            session_name: str | None = None,
     ) -> WorkerEndpoint:
         if is_local_mode is None:
             local_mode_env = os.getenv("EYEPOP_LOCAL_MODE", "")
@@ -187,6 +193,7 @@ class EyePopSdk:
             dataset_uuid=dataset_uuid,
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
+            session_name=session_name,
         )
         return endpoint
 

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -62,6 +62,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            session_name: str | None = None,
     ):
         super().__init__(
             secret_key=secret_key,
@@ -82,6 +83,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 self.compute_ctx.pipeline_image = pipeline_image
             if pipeline_version:
                 self.compute_ctx.pipeline_version = pipeline_version
+            if session_name:
+                self.compute_ctx.session_name = session_name
             self.is_dev_mode = not bool(session_uuid)
         else:
             self.is_dev_mode = True

--- a/scripts/session_smoke.py
+++ b/scripts/session_smoke.py
@@ -7,12 +7,13 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 
 from eyepop import EyePopSdk, __version__
-from eyepop.worker.worker_types import InferenceComponent, Pop
+from eyepop.worker.worker_endpoint import WorkerEndpoint
+from eyepop.worker.worker_types import DynamicComponent, InferenceComponent, Pop
 
 DEFAULT_IMAGE = Path("tests/test.jpg")
 DESCRIPTION = "Run a deterministic SDK transient-session smoke test."
@@ -39,6 +40,11 @@ def parse_args() -> argparse.Namespace:
         "--api-key",
         default=os.getenv("EYEPOP_API_KEY"),
         help="EyePop API key. Defaults to EYEPOP_API_KEY.",
+    )
+    parser.add_argument(
+        "--session-name",
+        default=os.getenv("EYEPOP_SESSION_NAME"),
+        help="Optional transient session name for run correlation.",
     )
     parser.add_argument(
         "--image",
@@ -100,12 +106,18 @@ def require_inputs(args: argparse.Namespace) -> None:
 
 
 def build_pop(args: argparse.Namespace) -> Pop:
+    component = cast(
+        DynamicComponent,
+        InferenceComponent(
+            ability=args.ability,
+            categoryName=args.expected_class,
+            modelUuid=None,
+            model=None,
+        ),
+    )
     return Pop(
         components=[
-            InferenceComponent(
-                ability=args.ability,
-                categoryName=args.expected_class,
-            )
+            component
         ]
     )
 
@@ -195,6 +207,7 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
         "expected_class": args.expected_class,
         "min_objects": args.min_objects,
         "min_confidence": args.min_confidence,
+        "session_name": args.session_name or "",
         "session_uuid": "",
         "session_uuid_short": "",
         "cleanup": {"ok": True, "result": "not_started"},
@@ -205,7 +218,9 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
             pop_id="transient",
             api_key=args.api_key,
             eyepop_url=eyepop_url,
-        ) as endpoint:
+            session_name=args.session_name,
+        ) as raw_endpoint:
+            endpoint = cast(WorkerEndpoint, raw_endpoint)
             await endpoint.set_pop(build_pop(args))
             compute_ctx = getattr(endpoint, "compute_ctx", None)
             session_uuid = getattr(compute_ctx, "session_uuid", "") or ""
@@ -275,6 +290,7 @@ async def main() -> int:
         summary = {
             "ok": False,
             "environment": args.environment,
+            "session_name": args.session_name or "",
             "error": f"{type(exc).__name__}: {exc}",
         }
 

--- a/scripts/session_smoke.py
+++ b/scripts/session_smoke.py
@@ -101,6 +101,9 @@ def require_inputs(args: argparse.Namespace) -> None:
     if args.min_objects < 1:
         raise ValueError("--min-objects must be at least 1")
 
+    if not 0.0 <= args.min_confidence <= 1.0:
+        raise ValueError("--min-confidence must be between 0.0 and 1.0")
+
     if not args.image.is_file():
         raise FileNotFoundError(f"Image fixture does not exist: {args.image}")
 
@@ -136,11 +139,13 @@ def matching_objects(result: dict[str, Any], expected_class: str, min_confidence
         return []
 
     matches = []
+    expected = expected_class.strip().lower()
     for obj in objects:
         if not isinstance(obj, dict):
             continue
         confidence = obj.get("confidence", 0)
-        if object_label(obj) == expected_class and isinstance(confidence, (int, float)) and confidence >= min_confidence:
+        detected = object_label(obj).strip().lower()
+        if detected == expected and isinstance(confidence, (int, float)) and confidence >= min_confidence:
             matches.append(obj)
     return matches
 

--- a/scripts/session_smoke.py
+++ b/scripts/session_smoke.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from eyepop import EyePopSdk, __version__
+from eyepop.worker.worker_types import InferenceComponent, Pop
+
+DEFAULT_IMAGE = Path("tests/test.jpg")
+DESCRIPTION = "Run a deterministic SDK transient-session smoke test."
+ENV_URLS = {
+    "production": "https://compute.eyepop.ai",
+    "staging": "https://compute.staging.eyepop.xyz",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument(
+        "--environment",
+        choices=sorted(ENV_URLS.keys()),
+        default=os.getenv("EYEPOP_ENV", "production"),
+        help="EyePop environment to smoke.",
+    )
+    parser.add_argument(
+        "--eyepop-url",
+        default=os.getenv("EYEPOP_URL"),
+        help="Compute API base URL. Defaults from --environment.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("EYEPOP_API_KEY"),
+        help="EyePop API key. Defaults to EYEPOP_API_KEY.",
+    )
+    parser.add_argument(
+        "--image",
+        type=Path,
+        default=DEFAULT_IMAGE,
+        help="Local image fixture to upload for inference.",
+    )
+    parser.add_argument(
+        "--ability",
+        default=os.getenv("EYEPOP_SMOKE_ABILITY", "eyepop.person:latest"),
+        help="Pipeline ability alias for the smoke pop.",
+    )
+    parser.add_argument(
+        "--expected-class",
+        default=os.getenv("EYEPOP_SMOKE_EXPECTED_CLASS", "person"),
+        help="Object class label required in the result.",
+    )
+    parser.add_argument(
+        "--min-objects",
+        type=int,
+        default=int(os.getenv("EYEPOP_SMOKE_MIN_OBJECTS", "1")),
+        help="Minimum matching objects required.",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=float(os.getenv("EYEPOP_SMOKE_MIN_CONFIDENCE", "0.5")),
+        help="Minimum confidence for matching objects.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=float(os.getenv("EYEPOP_SMOKE_TIMEOUT_SECONDS", "600")),
+        help="Overall smoke timeout.",
+    )
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=Path(os.getenv("EYEPOP_SMOKE_SUMMARY_JSON", "session-smoke-summary.json")),
+        help="Path to write machine-readable run summary.",
+    )
+    parser.add_argument(
+        "--no-cleanup",
+        action="store_true",
+        help="Skip transient session deletion. Intended only for local debugging.",
+    )
+    return parser.parse_args()
+
+
+def require_inputs(args: argparse.Namespace) -> None:
+    if not args.api_key:
+        raise ValueError("Missing EYEPOP_API_KEY")
+
+    if args.min_objects < 1:
+        raise ValueError("--min-objects must be at least 1")
+
+    if not args.image.is_file():
+        raise FileNotFoundError(f"Image fixture does not exist: {args.image}")
+
+
+def build_pop(args: argparse.Namespace) -> Pop:
+    return Pop(
+        components=[
+            InferenceComponent(
+                ability=args.ability,
+                categoryName=args.expected_class,
+            )
+        ]
+    )
+
+
+def object_label(obj: dict[str, Any]) -> str:
+    for key in ("classLabel", "category", "categoryName", "label", "name"):
+        value = obj.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def matching_objects(result: dict[str, Any], expected_class: str, min_confidence: float) -> list[dict[str, Any]]:
+    objects = result.get("objects") or []
+    if not isinstance(objects, list):
+        return []
+
+    matches = []
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        confidence = obj.get("confidence", 0)
+        if object_label(obj) == expected_class and isinstance(confidence, (int, float)) and confidence >= min_confidence:
+            matches.append(obj)
+    return matches
+
+
+def summarize_predictions(
+    predictions: list[dict[str, Any]],
+    expected_class: str,
+    min_confidence: float,
+) -> dict[str, Any]:
+    all_objects = []
+    matches = []
+    for result in predictions:
+        objects = result.get("objects") or []
+        if isinstance(objects, list):
+            all_objects.extend(obj for obj in objects if isinstance(obj, dict))
+        matches.extend(matching_objects(result, expected_class, min_confidence))
+
+    return {
+        "prediction_count": len(predictions),
+        "object_count": len(all_objects),
+        "matching_object_count": len(matches),
+        "top_matches": [
+            {
+                "class": object_label(obj),
+                "confidence": obj.get("confidence"),
+                "x": obj.get("x"),
+                "y": obj.get("y"),
+                "width": obj.get("width"),
+                "height": obj.get("height"),
+            }
+            for obj in matches[:5]
+        ],
+    }
+
+
+async def delete_transient_session(api_key: str, eyepop_url: str, session_uuid: str) -> dict[str, Any]:
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    url = f"{eyepop_url.rstrip('/')}/v1/sessions/{session_uuid}"
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(url, headers=headers) as response:
+            body = await response.text()
+            ok = response.status in (200, 202, 204, 404)
+            return {
+                "ok": ok,
+                "status": response.status,
+                "result": "deleted" if response.status != 404 else "already_absent",
+                "body": body[:300] if body and not ok else "",
+            }
+
+
+async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    require_inputs(args)
+
+    eyepop_url = args.eyepop_url or ENV_URLS[args.environment]
+    started = time.monotonic()
+    session_uuid = ""
+    summary: dict[str, Any] = {
+        "ok": False,
+        "environment": args.environment,
+        "sdk_version": __version__,
+        "eyepop_url": eyepop_url,
+        "image": str(args.image),
+        "ability": args.ability,
+        "expected_class": args.expected_class,
+        "min_objects": args.min_objects,
+        "min_confidence": args.min_confidence,
+        "session_uuid": "",
+        "session_uuid_short": "",
+        "cleanup": {"ok": True, "result": "not_started"},
+    }
+
+    try:
+        async with EyePopSdk.async_worker(
+            pop_id="transient",
+            api_key=args.api_key,
+            eyepop_url=eyepop_url,
+        ) as endpoint:
+            await endpoint.set_pop(build_pop(args))
+            compute_ctx = getattr(endpoint, "compute_ctx", None)
+            session_uuid = getattr(compute_ctx, "session_uuid", "") or ""
+            summary["session_uuid"] = session_uuid
+            summary["session_uuid_short"] = session_uuid[:8] if session_uuid else ""
+
+            job = await endpoint.upload(str(args.image))
+            predictions: list[dict[str, Any]] = []
+            while result := await job.predict():
+                if isinstance(result, dict):
+                    predictions.append(result)
+
+            prediction_summary = summarize_predictions(
+                predictions,
+                expected_class=args.expected_class,
+                min_confidence=args.min_confidence,
+            )
+            summary.update(prediction_summary)
+
+            smoke_ok = (
+                prediction_summary["prediction_count"] > 0
+                and prediction_summary["matching_object_count"] >= args.min_objects
+            )
+            if not smoke_ok:
+                summary["error"] = (
+                    f"Expected at least {args.min_objects} {args.expected_class!r} objects "
+                    f"with confidence >= {args.min_confidence}; got "
+                    f"{prediction_summary['matching_object_count']}"
+                )
+    except Exception as exc:
+        summary["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        if session_uuid and not args.no_cleanup:
+            try:
+                summary["cleanup"] = await delete_transient_session(
+                    api_key=args.api_key,
+                    eyepop_url=eyepop_url,
+                    session_uuid=session_uuid,
+                )
+            except Exception as exc:
+                summary["cleanup"] = {
+                    "ok": False,
+                    "result": "error",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+        elif args.no_cleanup:
+            summary["cleanup"] = {"ok": True, "result": "skipped"}
+        else:
+            summary["cleanup"] = {"ok": False, "result": "missing_session_uuid"}
+
+    summary["duration_seconds"] = round(time.monotonic() - started, 3)
+    summary["ok"] = "error" not in summary and bool(summary.get("cleanup", {}).get("ok", False))
+    return summary
+
+
+def write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+
+async def main() -> int:
+    args = parse_args()
+    summary: dict[str, Any]
+    try:
+        summary = await asyncio.wait_for(run_smoke(args), timeout=args.timeout_seconds)
+    except Exception as exc:
+        summary = {
+            "ok": False,
+            "environment": args.environment,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    write_summary(args.summary_json, summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -264,6 +264,41 @@ async def test_creates_session_with_pipeline_image(aioresponses):
 
 
 @pytest.mark.asyncio
+async def test_creates_session_with_session_name(aioresponses):
+    ctx = ComputeContext(
+        compute_url="https://compute.staging.eyepop.xyz",
+        api_key="test-api-key",
+        session_name="sessions-smoke-123",
+    )
+
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[],
+        status=200,
+    )
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        payload={**MOCK_SESSION_RESPONSE, "session_name": "sessions-smoke-123"},
+        status=200,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(ctx, session)
+
+    aioresponses.assert_called_with(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        method="POST",
+        headers={
+            "Authorization": "Bearer test-api-key",
+            "Accept": "application/json",
+        },
+        data=None,
+        json={"session_name": "sessions-smoke-123"},
+    )
+    assert result.session_name == "sessions-smoke-123"
+
+
+@pytest.mark.asyncio
 async def test_creates_session_without_pipeline_image(aioresponses):
     """Test that no body is sent when pipeline_image is not set."""
     ctx = ComputeContext(

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -278,7 +278,7 @@ async def test_creates_session_with_session_name(aioresponses):
     )
     aioresponses.post(
         "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
-        payload={**MOCK_SESSION_RESPONSE, "session_name": "sessions-smoke-123"},
+        payload={**MOCK_SESSION_RESPONSE, "session_name": "server-session-456"},
         status=200,
     )
 
@@ -295,7 +295,7 @@ async def test_creates_session_with_session_name(aioresponses):
         data=None,
         json={"session_name": "sessions-smoke-123"},
     )
-    assert result.session_name == "sessions-smoke-123"
+    assert result.session_name == "server-session-456"
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -16,6 +16,17 @@ class TestEndpointConnect(BaseEndpointTest):
         with self.assertRaises(KeyError):
             EyePopSdk.sync_worker()
 
+    def test_session_name_sets_compute_context(self):
+        endpoint = EyePopSdk.async_worker(
+            eyepop_url="https://compute.eyepop.ai",
+            api_key="test-api-key",
+            pop_id="transient",
+            session_name="sessions-smoke-123",
+        )
+
+        self.assertIsNotNone(endpoint.compute_ctx)
+        self.assertEqual(endpoint.compute_ctx.session_name, "sessions-smoke-123")
+
     @aioresponses()
     def test_connect_ok(self, mock: aioresponses):
 


### PR DESCRIPTION
## Summary
- Add a scheduled sessions smoke workflow that validates transient SDK inference against production.
- Add a deterministic SDK smoke script using the committed person-detection fixture and cleanup of only the transient session used by the run.
- Support Slack status alerts and manual dispatch against `latest`, `source`, or an exact SDK package version.

## Changes
- `.github/workflows/session-smoke.yml` runs twice daily against production and supports manual staging/production dispatch.
- `scripts/session_smoke.py` installs cleanly as an operational smoke harness over the public SDK APIs.
- `CHANGELOG.md` documents the new scheduled smoke workflow.

## Test plan
- [x] `uv run ruff check scripts/session_smoke.py`
- [x] `uv run python -m py_compile scripts/session_smoke.py`
- [x] workflow YAML parse check
- [x] `task check`
- [x] missing-key dry run writes a failing JSON summary and exits nonzero

## Notes
- Scheduled runs test the latest published PyPI SDK package by default.
- Manual `sdk_version=source` tests the checked-out branch source.
- Manual `sdk_version=<version>` installs that exact PyPI package version.
- The workflow expects `EYEPOP_API_KEY`; `SLACK_WEBHOOK_URL` is optional for Slack notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled/manual "sessions smoke" workflow with selectable SDK version, JSON run summary artifact, GitHub UI summary, and optional Slack status alerts.
  * CLI smoke-test that runs transient inference, uploads an image, summarizes results, enforces minimum matches, and optionally cleans up the transient session.
  * Optional session naming for worker sessions via environment variable.
* **Documentation**
  * Changelog updated with the workflow and session_name support.
* **Tests**
  * Added tests verifying session_name propagation and session-creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->