### PR TITLE
[SDK]: Allow targeting existing worker pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Scheduled sessions smoke workflow for validating transient SDK inference against production with optional Slack status alerts and selectable SDK package versions.
+- `pipeline_id` support on worker session creation for targeting an existing pipeline in a transient session.
 - `session_name` support on worker session creation, also configurable via `EYEPOP_SESSION_NAME`.
 
 ### Fixed

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -132,8 +132,8 @@ def _compute_context_from_response(compute_ctx: ComputeContext, res: dict | None
     compute_ctx.m2m_access_token = session_response.access_token
     compute_ctx.access_token_expires_at = session_response.access_token_expires_at
     compute_ctx.access_token_expires_in = session_response.access_token_expires_in
-    pipeline_id = ""
-    if len(session_response.pipelines) > 0:
+    pipeline_id = compute_ctx.pipeline_id
+    if not pipeline_id and len(session_response.pipelines) > 0:
         pipeline_id = session_response.pipelines[0].get("id", None)
         if not pipeline_id:
             pipeline_id = session_response.pipelines[0].get("pipeline_id", "")

--- a/eyepop/eyepopsdk.py
+++ b/eyepop/eyepopsdk.py
@@ -33,6 +33,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            pipeline_id: str | None = None,
             session_name: str | None = None,
     ) -> WorkerEndpoint | SyncWorkerEndpoint:
         if is_async:
@@ -51,6 +52,7 @@ class EyePopSdk:
                 dataset_uuid=dataset_uuid,
                 pipeline_image=pipeline_image,
                 pipeline_version=pipeline_version,
+                pipeline_id=pipeline_id,
                 session_name=session_name,
             )
         else:
@@ -69,6 +71,7 @@ class EyePopSdk:
                 dataset_uuid=dataset_uuid,
                 pipeline_image=pipeline_image,
                 pipeline_version=pipeline_version,
+                pipeline_id=pipeline_id,
                 session_name=session_name,
             )
 
@@ -88,6 +91,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            pipeline_id: str | None = None,
             session_name: str | None = None,
     ) -> SyncWorkerEndpoint:
         endpoint = EyePopSdk.async_worker(
@@ -105,6 +109,7 @@ class EyePopSdk:
             dataset_uuid=dataset_uuid,
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
+            pipeline_id=pipeline_id,
             session_name=session_name,
         )
         return SyncWorkerEndpoint(endpoint)
@@ -125,6 +130,7 @@ class EyePopSdk:
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            pipeline_id: str | None = None,
             session_name: str | None = None,
     ) -> WorkerEndpoint:
         if is_local_mode is None:
@@ -193,6 +199,7 @@ class EyePopSdk:
             dataset_uuid=dataset_uuid,
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
+            pipeline_id=pipeline_id,
             session_name=session_name,
         )
         return endpoint

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -78,15 +78,15 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         self.auto_start = auto_start
         self.stop_jobs = stop_jobs
         self.dataset_uuid = dataset_uuid
-        self.requested_pipeline_id = pipeline_id
+        self.requested_pipeline_id = pipeline_id or None
 
         if self.compute_ctx:
             if pipeline_image:
                 self.compute_ctx.pipeline_image = pipeline_image
             if pipeline_version:
                 self.compute_ctx.pipeline_version = pipeline_version
-            if pipeline_id:
-                self.compute_ctx.pipeline_id = pipeline_id
+            if self.requested_pipeline_id:
+                self.compute_ctx.pipeline_id = self.requested_pipeline_id
             if session_name:
                 self.compute_ctx.session_name = session_name
             self.is_dev_mode = not bool(session_uuid)

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -62,6 +62,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             dataset_uuid: str | None = None,
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
+            pipeline_id: str | None = None,
             session_name: str | None = None,
     ):
         super().__init__(
@@ -77,12 +78,15 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         self.auto_start = auto_start
         self.stop_jobs = stop_jobs
         self.dataset_uuid = dataset_uuid
+        self.requested_pipeline_id = pipeline_id
 
         if self.compute_ctx:
             if pipeline_image:
                 self.compute_ctx.pipeline_image = pipeline_image
             if pipeline_version:
                 self.compute_ctx.pipeline_version = pipeline_version
+            if pipeline_id:
+                self.compute_ctx.pipeline_id = pipeline_id
             if session_name:
                 self.compute_ctx.session_name = session_name
             self.is_dev_mode = not bool(session_uuid)
@@ -113,6 +117,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             client_timeout = aiohttp.ClientTimeout(total=timeout)
         if (self.is_dev_mode and self.pop_id == 'transient'
                 and self.worker_config is not None and self.worker_config.get('pipeline_id') is not None
+                and self.requested_pipeline_id is None
                 and self.client_session is not None):
             try:
                 base_url = await self.dev_mode_base_url()
@@ -173,6 +178,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             try:
                 async with self.client_session.get(config_url, headers=headers) as response:
                     self.worker_config = await response.json()
+                    if self.requested_pipeline_id:
+                        self.worker_config['pipeline_id'] = self.requested_pipeline_id
                 self.last_fetch_config_success_time = time.time()
                 self.last_fetch_config_error = None
                 self.last_fetch_config_error_time = None
@@ -190,6 +197,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                         headers['Authorization'] = authorization_header
                     async with self.client_session.get(config_url, headers=headers) as retried_response:
                         self.worker_config = await retried_response.json()
+                        if self.requested_pipeline_id:
+                            self.worker_config['pipeline_id'] = self.requested_pipeline_id
             except aiohttp.ClientConnectionError as e:
                 self.last_fetch_config_error = e
                 self.last_fetch_config_error_time = time.time()
@@ -203,7 +212,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if self.worker_config.get('status') == 'active_prod':
             self.is_dev_mode = False
 
-        if self.is_dev_mode:
+        if self.is_dev_mode and self.requested_pipeline_id is None:
             start_pipeline_url = f'{base_url}/pipelines'
             body = {
                 "pop": self.pop.model_dump() if self.pop else {},
@@ -235,7 +244,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             if not has_base_url or not has_pipeline_id:
                 raise PopNotStartedException(pop_id=self.pop_id)
 
-        if self.is_dev_mode and self.stop_jobs:
+        if self.is_dev_mode and self.stop_jobs and self.requested_pipeline_id is None:
             stop_jobs_url = f'{await self.dev_mode_pipeline_base_url()}/source?mode=preempt&processing=sync'
             body = {'sourceType': 'NONE'}
             headers = {}

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -4,7 +4,11 @@ import aiohttp
 import pytest
 
 from eyepop.compute import ComputeContext
-from eyepop.compute.api import fetch_new_compute_session, fetch_session_endpoint
+from eyepop.compute.api import (
+    fetch_new_compute_session,
+    fetch_permanent_compute_session,
+    fetch_session_endpoint,
+)
 from eyepop.exceptions import ComputeSessionException
 
 MOCK_SESSION_RESPONSE = {
@@ -48,6 +52,58 @@ async def test_fetches_existing_session_successfully(mock_compute_config, aiores
     assert result.session_endpoint == "https://pipeline.example.com"
     assert result.m2m_access_token == "jwt-token-123"
     assert result.pipeline_id == "pipeline-123"
+
+
+@pytest.mark.asyncio
+async def test_preserves_requested_pipeline_id_when_session_has_multiple_pipelines(aioresponses):
+    ctx = ComputeContext(
+        compute_url="https://compute.staging.eyepop.xyz",
+        api_key="test-api-key",
+        pipeline_id="pipeline-requested",
+    )
+    response = {
+        **MOCK_SESSION_RESPONSE,
+        "pipelines": [
+            {"pipeline_id": "agent-camera_1-vehicle_tracking"},
+            {"pipeline_id": "pipeline-requested"},
+        ],
+    }
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[response],
+        status=200
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(ctx, session)
+
+    assert result.pipeline_id == "pipeline-requested"
+
+
+@pytest.mark.asyncio
+async def test_preserves_requested_pipeline_id_for_permanent_session(aioresponses):
+    ctx = ComputeContext(
+        compute_url="https://compute.staging.eyepop.xyz",
+        api_key="test-api-key",
+        pipeline_id="pipeline-requested",
+    )
+    response = {
+        **MOCK_SESSION_RESPONSE,
+        "pipelines": [
+            {"pipeline_id": "agent-camera_1-vehicle_tracking"},
+            {"pipeline_id": "pipeline-requested"},
+        ],
+    }
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions/session-456",
+        payload=response,
+        status=200
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_permanent_compute_session(ctx, session, "session-456")
+
+    assert result.pipeline_id == "pipeline-requested"
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -112,7 +112,7 @@ class TestEndpointConnect(BaseEndpointTest):
     @aioresponses()
     def test_connect_transient_with_pipeline_id_targets_existing_pipeline(self, mock: aioresponses):
         target_pipeline_id = "agent-camera_1-vehicle_tracking"
-        self.setup_base_mock(mock)
+        self.setup_base_mock(mock, is_transient=True)
 
         mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
             {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
@@ -128,6 +128,21 @@ class TestEndpointConnect(BaseEndpointTest):
             self.assertEqual(endpoint.endpoint.load_balancer.get_debug_status()[0]["pipeline_id"], target_pipeline_id)
         finally:
             endpoint.disconnect()
+
+        mock.assert_called_with(
+            f'{self.test_eyepop_url}/workers/config',
+            method='GET',
+            headers={'Authorization': f'Bearer {self.test_access_token}'},
+        )
+        self.assertNotIn(('POST', f'{self.test_worker_url}/pipelines'), mock.requests)
+        self.assertNotIn(
+            (
+                'PATCH',
+                f'{self.test_worker_url}/pipelines/{target_pipeline_id}/source?mode=preempt&processing=sync',
+            ),
+            mock.requests,
+        )
+        self.assertNotIn(('DELETE', f'{self.test_worker_url}/pipelines/{target_pipeline_id}'), mock.requests)
 
     @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -110,6 +110,26 @@ class TestEndpointConnect(BaseEndpointTest):
         self.assertBaseMock(mock, is_transient=True)
 
     @aioresponses()
+    def test_connect_transient_with_pipeline_id_targets_existing_pipeline(self, mock: aioresponses):
+        target_pipeline_id = "agent-camera_1-vehicle_tracking"
+        self.setup_base_mock(mock)
+
+        mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
+            {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+        endpoint = EyePopSdk.sync_worker(
+            eyepop_url=self.test_eyepop_url,
+            secret_key=self.test_eyepop_secret_key,
+            pop_id='transient',
+            pipeline_id=target_pipeline_id,
+        )
+        try:
+            endpoint.connect()
+            self.assertEqual(endpoint.endpoint.worker_config["pipeline_id"], target_pipeline_id)
+            self.assertEqual(endpoint.endpoint.load_balancer.get_debug_status()[0]["pipeline_id"], target_pipeline_id)
+        finally:
+            endpoint.disconnect()
+
+    @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):
         self.setup_base_mock(mock)
 


### PR DESCRIPTION
## Summary
- Adds a `pipeline_id` worker option so SDK callers can target an existing pipeline in a transient session.
- Preserves requested pipeline IDs when compute session responses include multiple pipelines.
- Avoids creating, stopping, or deleting SDK-managed dev pipelines when a caller supplies a pipeline ID.

## Changes
- Threads `pipeline_id` through `EyePopSdk.workerEndpoint`, `sync_worker`, `async_worker`, and `WorkerEndpoint`.
- Updates compute session response handling to keep an explicitly requested pipeline ID.
- Adds unit coverage for compute response preservation and transient worker pipeline targeting.

## Test plan
- [x] `uv run pytest tests/test_compute_api.py tests/worker/test_endpoint_connect.py`
- [x] `task check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional pipeline_id support when creating worker endpoints so transient workers can target existing pipelines.

* **Bug Fixes**
  * Preserve an already-requested pipeline selection instead of always falling back to the first available pipeline.

* **Tests**
  * Added coverage verifying targeted pipeline behavior for transient and permanent session flows.

* **Chores**
  * Updated unreleased changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->