### PR TITLE
[SDK]: Keep smoke compatible with released SDK

### DIFF
--- a/scripts/session_smoke.py
+++ b/scripts/session_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import json
 import os
 import sys
@@ -181,6 +182,22 @@ def summarize_predictions(
     }
 
 
+def sdk_supports_session_name() -> bool:
+    return "session_name" in inspect.signature(EyePopSdk.async_worker).parameters
+
+
+def async_worker_kwargs(args: argparse.Namespace, eyepop_url: str) -> tuple[dict[str, Any], bool]:
+    kwargs: dict[str, Any] = {
+        "pop_id": "transient",
+        "api_key": args.api_key,
+        "eyepop_url": eyepop_url,
+    }
+    session_name_supported = sdk_supports_session_name()
+    if args.session_name and session_name_supported:
+        kwargs["session_name"] = args.session_name
+    return kwargs, session_name_supported
+
+
 async def delete_transient_session(api_key: str, eyepop_url: str, session_uuid: str) -> dict[str, Any]:
     headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
     url = f"{eyepop_url.rstrip('/')}/v1/sessions/{session_uuid}"
@@ -200,6 +217,7 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
     require_inputs(args)
 
     eyepop_url = args.eyepop_url or ENV_URLS[args.environment]
+    worker_kwargs, session_name_supported = async_worker_kwargs(args, eyepop_url)
     started = time.monotonic()
     session_uuid = ""
     summary: dict[str, Any] = {
@@ -213,18 +231,15 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
         "min_objects": args.min_objects,
         "min_confidence": args.min_confidence,
         "session_name": args.session_name or "",
+        "session_name_supported": session_name_supported,
+        "session_name_applied": "session_name" in worker_kwargs,
         "session_uuid": "",
         "session_uuid_short": "",
         "cleanup": {"ok": True, "result": "not_started"},
     }
 
     try:
-        async with EyePopSdk.async_worker(
-            pop_id="transient",
-            api_key=args.api_key,
-            eyepop_url=eyepop_url,
-            session_name=args.session_name,
-        ) as raw_endpoint:
+        async with EyePopSdk.async_worker(**worker_kwargs) as raw_endpoint:
             endpoint = cast(WorkerEndpoint, raw_endpoint)
             await endpoint.set_pop(build_pop(args))
             compute_ctx = getattr(endpoint, "compute_ctx", None)


### PR DESCRIPTION
## Summary
- Fixes scheduled sessions smoke failures when `sdk_version=latest` installs the current PyPI SDK before `session_name` support is released.
- Detects whether `EyePopSdk.async_worker` supports `session_name` before passing it.
- Records `session_name_supported` and `session_name_applied` in the smoke summary for future debugging.

## Failure
- Scheduled production smoke run failed with `TypeError: EyePopSdk.async_worker() got an unexpected keyword argument 'session_name'` while running `eyepop==3.15.5`.
- Failed run: https://github.com/eyepop-ai/eyepop-sdk-python/actions/runs/27024189770

## Test plan
- [x] Source SDK helper includes `session_name`
- [x] PyPI `eyepop==3.15.5` helper omits `session_name`
- [x] `task check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDK compatibility by automatically detecting session name support across different versions.

* **New Features**
  * Enhanced session management with capability detection and comprehensive support reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->