### PR TITLE
[SDK]: Multi-image (Image Group) sources — upload_group (VREE-288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ with EyePopSdk.sync_worker() as endpoint:
 
 Cancel a job mid-stream with `job.cancel()`.
 
+### Image groups (multiple images, one result)
+
+Send several images as a **single** source that the pop processes **together** as
+one inference unit — for example a multi-image VLM prompt. The group yields
+**one** prediction for the whole set, unlike [Batching](#batching) below, where
+each image is an independent inference.
+
+```python
+with EyePopSdk.sync_worker() as endpoint:
+    # local files
+    result = endpoint.upload_group(['a.jpg', 'b.jpg', 'c.jpg']).predict()
+
+    # in-memory streams (optional parallel content types)
+    with open('a.jpg', 'rb') as a, open('b.jpg', 'rb') as b:
+        result = endpoint.upload_stream_group([a, b]).predict()
+
+    # remote URLs (the server fetches each)
+    result = endpoint.load_from_group([
+        'https://example.com/a.jpg',
+        'https://example.com/b.jpg',
+    ]).predict()
+```
+
+Image order is preserved end-to-end. A group may contain **up to 16 images**
+(enforced server-side). The pop's ability must be multi-image-capable; a
+single-image ability handed a group returns an error.
+
 ### Batching
 
 Queue multiple uploads, then collect results:

--- a/examples/multi_image_group_demo.py
+++ b/examples/multi_image_group_demo.py
@@ -1,0 +1,59 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from eyepop import EyePopSdk
+from eyepop.worker.worker_types import InferenceComponent, Pop
+
+logging.getLogger('eyepop.requests').setLevel(logging.INFO)
+log = logging.getLogger('eyepop.example')
+
+parser = argparse.ArgumentParser(
+    prog='Multi-image group demo',
+    description='Send several images as a single image group (one inference unit) '
+                'to a multi-image-capable VLM ability and print the one result.',
+    epilog='.')
+parser.add_argument('-l', '--local-paths', nargs='+', default=None,
+                    help='two or more local image files to send as one group')
+parser.add_argument('-u', '--urls', nargs='+', default=None,
+                    help='two or more remote image URLs to send as one group')
+parser.add_argument('-a', '--ability', type=str, default='eyepop.vlm.image:latest',
+                    help='a multi-image-capable ability')
+parser.add_argument('-p', '--prompt', type=str,
+                    default='Describe these images together in one sentence.',
+                    help='prompt for the VLM ability')
+
+args = parser.parse_args()
+
+if not args.local_paths and not args.urls:
+    print('Pass --local-paths or --urls with two or more images.')
+    parser.print_help()
+    sys.exit(1)
+
+group_pop = Pop(components=[
+    InferenceComponent(ability=args.ability, params={'prompt': args.prompt})
+])
+
+
+async def main():
+    async with EyePopSdk.async_worker() as endpoint:
+        await endpoint.set_pop(group_pop)
+
+        if args.local_paths:
+            for path in args.local_paths:
+                if not os.path.isfile(path):
+                    log.warning(f'local path {path} does not exist')
+                    sys.exit(1)
+            job = await endpoint.upload_group(args.local_paths)
+        else:
+            job = await endpoint.load_from_group(args.urls)
+
+        # A group is one inference unit: expect a single result.
+        result = await job.predict()
+        print(json.dumps(result, indent=2))
+
+
+asyncio.run(main())

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -21,7 +21,9 @@ from eyepop.worker.worker_jobs import (
     WorkerJob,
     _LoadFromAssetUuidJob,
     _LoadFromJob,
+    _UploadFileGroupJob,
     _UploadFileJob,
+    _UploadStreamGroupJob,
     _UploadStreamJob,
 )
 from eyepop.worker.worker_types import ComponentParams, MotionDetectConfig, Pop, VideoMode
@@ -366,6 +368,62 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         await self._task_start(job.execute())
         return job
 
+    async def upload_stream_group(
+            self,
+            streams: list[BinaryIO],
+            mime_types: list[str] | None = None,
+            params: list[ComponentParams] | None = None,
+            roi: Area | None = None,
+            media_cache_seconds: int | None = None,
+            on_ready: Callable[[WorkerJob], None] | None = None
+    ) -> WorkerJob:
+        """Uploads multiple in-memory streams as a single image group (one inference unit).
+
+        The streams are processed together and yield a single prediction stream;
+        order follows `streams`. `mime_types`, if given, is a parallel list setting
+        each stream's content type and must match `streams` in length; if omitted,
+        no per-stream content type is sent. `params`, `roi`, and
+        `media_cache_seconds` apply once to the whole group.
+        """
+        job = _UploadStreamGroupJob(
+            streams=streams,
+            mime_types=mime_types,
+            component_params=params,
+            roi=roi,
+            media_cache_seconds=media_cache_seconds,
+            session=self,
+            on_ready=on_ready,
+            callback=self.metrics_collector
+        )
+        await self._task_start(job.execute())
+        return job
+
+    async def upload_group(
+            self,
+            locations: list[str],
+            params: list[ComponentParams] | None = None,
+            roi: Area | None = None,
+            media_cache_seconds: int | None = None,
+            on_ready: Callable[[WorkerJob], None] | None = None
+    ) -> WorkerJob:
+        """Uploads multiple local images as a single image group (one inference unit).
+
+        The images are processed together and yield a single prediction stream.
+        Image order follows `locations`. Unlike `upload`, there is no `video_mode`
+        or `motion_detect` (a group is still images); `params`, `roi`, and
+        `media_cache_seconds` apply once to the whole group.
+        """
+        job = _UploadFileGroupJob(
+            locations=locations,
+            component_params=params,
+            roi=roi,
+            media_cache_seconds=media_cache_seconds,
+            session=self, on_ready=on_ready,
+            callback=self.metrics_collector
+        )
+        await self._task_start(job.execute())
+        return job
+
     async def load_from(
             self,
             location: str,
@@ -377,11 +435,40 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             on_ready: Callable[[WorkerJob], None] | None = None
     ) -> WorkerJob:
         job = _LoadFromJob(
-            location=location,
+            locations=[location],
             component_params=params,
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
+            session=self,
+            on_ready=on_ready,
+            callback=self.metrics_collector
+        )
+        await self._task_start(job.execute())
+        return job
+
+    async def load_from_group(
+            self,
+            locations: list[str],
+            params: list[ComponentParams] | None = None,
+            roi: Area | None = None,
+            media_cache_seconds: int | None = None,
+            on_ready: Callable[[WorkerJob], None] | None = None
+    ) -> WorkerJob:
+        """Loads multiple server-fetched URLs as a single image group (one inference unit).
+
+        The URLs are processed together and yield a single prediction stream;
+        order follows `locations`. The server fetches each URL and reads its own
+        content type, so no mime type is supplied. `params`, `roi`, and
+        `media_cache_seconds` apply once to the whole group.
+        """
+        job = _LoadFromJob(
+            locations=locations,
+            component_params=params,
+            motion_detect=None,
+            roi=roi,
+            fps=None,
             media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,

--- a/eyepop/worker/worker_jobs.py
+++ b/eyepop/worker/worker_jobs.py
@@ -93,16 +93,36 @@ class WorkerJob(Job):
         return got_results
 
 
-class _UploadJob(WorkerJob):
-    mime_type: str
-    video_mode: VideoMode | None
+class _UploadSource:
+    """One media item to upload: a fresh-stream opener and its optional mime type.
+
+    mime_type may be None when it cannot be derived (a raw stream group with no
+    caller-supplied mime); the server no longer requires a per-member content type.
+    """
     open_stream: Callable[[], Any]
+    mime_type: str | None
+
+    def __init__(self, open_stream: Callable[[], Any], mime_type: str | None):
+        self.open_stream = open_stream
+        self.mime_type = mime_type
+
+
+class _UploadJob(WorkerJob):
+    """Uploads one or more media items as a single source.
+
+    A single item is posted as before: a raw body (or multipart when
+    params/roi/fps are present, or full-duplex for video). Two or more items are
+    posted together as one multipart request with an ordered 'file' part each -
+    an image group (server SOURCE_GROUP): one inference unit, one prediction
+    stream, member order preserved.
+    """
+    sources: list[_UploadSource]
+    video_mode: VideoMode | None
     needs_full_duplex: bool
 
     def __init__(
             self,
-            mime_type: str,
-            open_stream: Callable[[], Any],
+            sources: list[_UploadSource],
             video_mode: VideoMode | None,
             component_params: list[ComponentParams] | None,
             motion_detect: MotionDetectConfig | None,
@@ -125,10 +145,17 @@ class _UploadJob(WorkerJob):
             callback=callback,
             version=version
         )
-        self.mime_type = mime_type
+        if not sources:
+            raise ValueError("upload requires at least one source")
+        self.sources = sources
         self.video_mode = video_mode
-        self.open_stream = open_stream
-        self.needs_full_duplex = self.mime_type.startswith("video/")
+        # Full duplex is only used for a single video upload; an image group is
+        # always posted as one sync multipart request.
+        self.needs_full_duplex = (
+            len(sources) == 1
+            and sources[0].mime_type is not None
+            and sources[0].mime_type.startswith("video/")
+        )
 
     def open_mp_writer(self):
         mp_writer = aiohttp.MultipartWriter('form-data')
@@ -144,8 +171,12 @@ class _UploadJob(WorkerJob):
             fps_part = mp_writer.append_json(self._fps)
             fps_part.set_content_disposition('form-data', name='fps', filename='blob')
 
-        file_part = mp_writer.append(self.open_stream(), {'Content-Type': self.mime_type})
-        file_part.set_content_disposition('form-data', name='file', filename='blob')
+        for source in self.sources:
+            if source.mime_type is not None:
+                file_part = mp_writer.append(source.open_stream(), {'Content-Type': source.mime_type})
+            else:
+                file_part = mp_writer.append(source.open_stream())
+            file_part.set_content_disposition('form-data', name='file', filename='blob')
         return mp_writer
 
 
@@ -161,6 +192,11 @@ class _UploadJob(WorkerJob):
             query_params.update(self._motion_detect.model_dump(exclude_none=True))
         if self._media_cache_seconds is not None:
             query_params['mediaCacheSeconds'] = self._media_cache_seconds
+
+        # A single item with no extra parts can stream its raw body; anything
+        # else (extra parts, or a multi-item image group) is sent as multipart.
+        single_source = self.sources[0] if len(self.sources) == 1 else None
+        no_extra_parts = self._component_params is None and self._roi is None and self._fps is None
 
         if self.needs_full_duplex:
             self._response = await session.pipeline_post(
@@ -183,11 +219,11 @@ class _UploadJob(WorkerJob):
             query_params['processing'] = 'async'
             query_params['sourceId'] = source_id
             upload_url = f'source?{urlencode(query_params)}'
-            if self._component_params is None and self._roi is None and self._fps is None:
+            if single_source is not None and no_extra_parts:
                 upload_coro = session.pipeline_post(upload_url,
                                                     accept='application/jsonl',
-                                                    open_data=self.open_stream,
-                                                    content_type=self.mime_type,
+                                                    open_data=single_source.open_stream,
+                                                    content_type=single_source.mime_type,
                                                     timeout=aiohttp.ClientTimeout(total=None, sock_read=600))
             else:
                 upload_coro = session.pipeline_post(upload_url,
@@ -199,11 +235,11 @@ class _UploadJob(WorkerJob):
         else:
             query_params['processing'] = 'sync'
             upload_url = f'source?{urlencode(query_params)}'
-            if self._component_params is None and self._roi is None and self._fps is None:
+            if single_source is not None and no_extra_parts:
                 self._response = await session.pipeline_post(upload_url,
                                                              accept='application/jsonl',
-                                                             open_data=self.open_stream,
-                                                             content_type=self.mime_type,
+                                                             open_data=single_source.open_stream,
+                                                             content_type=single_source.mime_type,
                                                              timeout=aiohttp.ClientTimeout(total=None, sock_read=600))
             else:
                 self._response = await session.pipeline_post(upload_url,
@@ -221,6 +257,18 @@ def _guess_mime_type_from_location(location: str):
     return mime_type
 
 
+def _file_stream_opener(location: str) -> Callable[[], Any]:
+    def opener():
+        return open(location, 'rb')
+    return opener
+
+
+def _stream_opener(stream: BinaryIO) -> Callable[[], Any]:
+    def opener():
+        return stream
+    return opener
+
+
 class _UploadFileJob(_UploadJob):
     def __init__(
             self,
@@ -236,9 +284,11 @@ class _UploadFileJob(_UploadJob):
             callback: JobStateCallback | None = None,
             version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
     ):
+        self.location = location
         super().__init__(
-            mime_type=_guess_mime_type_from_location(location) or 'application/octet-stream',
-            open_stream=self._open_file_stream,
+            sources=[_UploadSource(
+                _file_stream_opener(location),
+                _guess_mime_type_from_location(location) or 'application/octet-stream')],
             video_mode=video_mode,
             component_params=component_params,
             motion_detect=motion_detect,
@@ -250,10 +300,6 @@ class _UploadFileJob(_UploadJob):
             callback=callback,
             version=version
         )
-        self.location = location
-
-    def _open_file_stream(self):
-        return open(self.location, 'rb')
 
 
 class _UploadStreamJob(_UploadJob):
@@ -272,9 +318,9 @@ class _UploadStreamJob(_UploadJob):
             callback: JobStateCallback | None = None,
             version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
     ):
+        self.stream = stream
         super().__init__(
-            mime_type=mime_type,
-            open_stream=self._get_opened_stream,
+            sources=[_UploadSource(self._get_opened_stream, mime_type)],
             video_mode=video_mode,
             component_params=component_params,
             motion_detect=motion_detect,
@@ -286,16 +332,109 @@ class _UploadStreamJob(_UploadJob):
             callback=callback,
             version=version
         )
-        self.stream = stream
 
     def _get_opened_stream(self):
         return self.stream
 
 
-class _LoadFromJob(WorkerJob):
+class _UploadFileGroupJob(_UploadJob):
+    """Uploads multiple local images by path as a single image group.
+
+    Thin builder over _UploadJob: one ordered _UploadSource per location (part
+    order is the canonical image order), each with a Content-Type derived from
+    its file extension, so it works against the current server without a
+    per-member mime type. Group size and member content-type limits are enforced
+    server-side.
+    """
+
     def __init__(
             self,
-            location: str,
+            locations: list[str],
+            component_params: list[ComponentParams] | None,
+            roi: Area | None,
+            media_cache_seconds: int | None,
+            session: WorkerClientSession,
+            on_ready: Callable[[WorkerJob], None] | None = None,
+            callback: JobStateCallback | None = None,
+            version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
+    ):
+        sources = [
+            _UploadSource(
+                _file_stream_opener(location),
+                _guess_mime_type_from_location(location) or 'application/octet-stream')
+            for location in locations
+        ]
+        super().__init__(
+            sources=sources,
+            video_mode=None,
+            component_params=component_params,
+            motion_detect=None,
+            roi=roi,
+            fps=None,
+            media_cache_seconds=media_cache_seconds,
+            session=session,
+            on_ready=on_ready,
+            callback=callback,
+            version=version
+        )
+
+
+class _UploadStreamGroupJob(_UploadJob):
+    """Uploads multiple in-memory streams as a single image group.
+
+    Thin builder over _UploadJob: one ordered _UploadSource per stream. The
+    optional mime_types list (parallel to streams) sets each part's Content-Type;
+    when omitted, parts carry no explicit content type, which the server accepts.
+    Group size limits are enforced server-side.
+    """
+
+    def __init__(
+            self,
+            streams: list[BinaryIO],
+            mime_types: list[str] | None,
+            component_params: list[ComponentParams] | None,
+            roi: Area | None,
+            media_cache_seconds: int | None,
+            session: WorkerClientSession,
+            on_ready: Callable[[WorkerJob], None] | None = None,
+            callback: JobStateCallback | None = None,
+            version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
+    ):
+        sources = [_UploadSource(_stream_opener(stream), None) for stream in streams]
+        super().__init__(
+            sources=sources,
+            video_mode=None,
+            component_params=component_params,
+            motion_detect=None,
+            roi=roi,
+            fps=None,
+            media_cache_seconds=media_cache_seconds,
+            session=session,
+            on_ready=on_ready,
+            callback=callback,
+            version=version
+        )
+        # Validate/apply mime types after super().__init__ so a bad call does not
+        # leave a half-constructed Job behind.
+        if mime_types is not None:
+            if len(mime_types) != len(streams):
+                raise ValueError("mime_types must have the same length as streams")
+            for source, mime_type in zip(self.sources, mime_types, strict=True):
+                source.mime_type = mime_type
+
+
+class _LoadFromJob(WorkerJob):
+    """Loads one or more server-fetched URLs as a single source.
+
+    A single URL is a normal `URL` source (unchanged, including video/motion/fps
+    handling). Two or more URLs form one `GROUP` source - an image group run as a
+    single inference unit, member order preserved. The server fetches each URL and
+    reads its own Content-Type, so no per-member mime type is sent.
+    """
+
+    def __init__(
+            self,
+            locations: list[str],
             component_params: list[ComponentParams] | None,
             motion_detect: MotionDetectConfig | None,
             roi: Area | None,
@@ -317,23 +456,40 @@ class _LoadFromJob(WorkerJob):
             callback=callback,
             version=version
         )
-        self.location = location
+        if not locations:
+            raise ValueError("load_from requires at least one url")
+        self.locations = list(locations)
         self.target_url = 'source?mode=queue&processing=sync'
-        self.body: dict[str, Any] = {
-            "sourceType": "URL",
-            "url": self.location,
-            "version": self._version,
-        }
-        if self._motion_detect is not None:
-            self.body.update(self._motion_detect.model_dump(exclude_none=True))
-        if self._component_params is not None:
-            self.body['params'] = TypeAdapter(list[ComponentParams]).dump_python(self._component_params)
-        if self._roi is not None:
-            self.body['roi'] = self._roi.model_dump(exclude_none=True)
-        if self._fps is not None:
-            self.body['fps'] = self._fps
-        if self._media_cache_seconds is not None:
-            self.body['mediaCacheSeconds'] = self._media_cache_seconds
+        if len(self.locations) == 1:
+            # Single URL: unchanged body (field order preserved for compatibility).
+            self.body: dict[str, Any] = {
+                "sourceType": "URL",
+                "url": self.locations[0],
+                "version": self._version,
+            }
+            if self._motion_detect is not None:
+                self.body.update(self._motion_detect.model_dump(exclude_none=True))
+            if self._component_params is not None:
+                self.body['params'] = TypeAdapter(list[ComponentParams]).dump_python(self._component_params)
+            if self._roi is not None:
+                self.body['roi'] = self._roi.model_dump(exclude_none=True)
+            if self._fps is not None:
+                self.body['fps'] = self._fps
+            if self._media_cache_seconds is not None:
+                self.body['mediaCacheSeconds'] = self._media_cache_seconds
+        else:
+            # Two or more URLs: one image group (no video/motion/fps).
+            self.body = {
+                "sourceType": "GROUP",
+                "sources": [{"sourceType": "URL", "url": location} for location in self.locations],
+                "version": self._version,
+            }
+            if self._component_params is not None:
+                self.body['params'] = TypeAdapter(list[ComponentParams]).dump_python(self._component_params)
+            if self._roi is not None:
+                self.body['roi'] = self._roi.model_dump(exclude_none=True)
+            if self._media_cache_seconds is not None:
+                self.body['mediaCacheSeconds'] = self._media_cache_seconds
 
         self.timeouts = aiohttp.ClientTimeout(total=None, sock_read=600)
 

--- a/eyepop/worker/worker_syncify.py
+++ b/eyepop/worker/worker_syncify.py
@@ -85,6 +85,50 @@ class SyncWorkerEndpoint(SyncEndpoint):
         ))
         return SyncWorkerJob(job, self.event_loop)
 
+    def upload_stream_group(
+            self,
+            streams: list[typing.BinaryIO],
+            mime_types: list[str] | None = None,
+            params: list[ComponentParams] | None = None,
+            roi: Area | None = None,
+            media_cache_seconds: int | None = None,
+            on_ready: typing.Callable[[WorkerJob], None] | None = None
+    ) -> SyncWorkerJob:
+        if on_ready is not None:
+            raise TypeError(
+                "'on_ready' callback not supported for sync endpoints. "
+                "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
+        job = run_coro_thread_save(self.event_loop, self.endpoint.upload_stream_group(
+            streams=streams,
+            mime_types=mime_types,
+            params=params,
+            roi=roi,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
+        ))
+        return SyncWorkerJob(job, self.event_loop)
+
+    def upload_group(
+            self,
+            locations: list[str],
+            params: list[ComponentParams] | None = None,
+            roi: Area | None = None,
+            media_cache_seconds: int | None = None,
+            on_ready: typing.Callable[[WorkerJob], None] | None = None
+    ) -> SyncWorkerJob:
+        if on_ready is not None:
+            raise TypeError(
+                "'on_ready' callback not supported for sync endpoints. "
+                "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
+        job = run_coro_thread_save(self.event_loop, self.endpoint.upload_group(
+            locations=locations,
+            params=params,
+            roi=roi,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
+        ))
+        return SyncWorkerJob(job, self.event_loop)
+
     def load_from(
             self,
             location: str,
@@ -105,6 +149,27 @@ class SyncWorkerEndpoint(SyncEndpoint):
             motion_detect=motion_detect,
             roi=roi,
             fps=fps,
+            media_cache_seconds=media_cache_seconds,
+            on_ready=None
+        ))
+        return SyncWorkerJob(job, self.event_loop)
+
+    def load_from_group(
+            self,
+            locations: list[str],
+            params: list[ComponentParams] | None = None,
+            roi: Area | None = None,
+            media_cache_seconds: int | None = None,
+            on_ready: typing.Callable[[WorkerJob], None] | None = None
+    ) -> SyncWorkerJob:
+        if on_ready is not None:
+            raise TypeError(
+                "'on_ready' callback not supported for sync endpoints. "
+                "Use 'EyePopSdk.workerEndpoint(is_async=True)` to create an async endpoint with callback support")
+        job = run_coro_thread_save(self.event_loop, self.endpoint.load_from_group(
+            locations=locations,
+            params=params,
+            roi=roi,
             media_cache_seconds=media_cache_seconds,
             on_ready=None
         ))

--- a/tests/integration/test_upload_group.py
+++ b/tests/integration/test_upload_group.py
@@ -1,0 +1,82 @@
+import os
+from importlib import resources
+
+import pytest
+
+import tests
+from eyepop import EyePopSdk
+from eyepop.worker.worker_types import InferenceComponent, Pop
+
+TEST_IMAGE = str(resources.files(tests) / 'test.jpg')
+PUBLIC_TEST_IMAGE_URL = "https://raw.githubusercontent.com/eyepop-ai/eyepop-sdk-python/main/tests/test.jpg"
+
+# A multi-image-capable VLM caption ability. Override via env if the default is
+# not multi-image-capable in the target environment.
+MULTI_IMAGE_ABILITY = os.getenv("EYEPOP_MULTI_IMAGE_ABILITY", "eyepop.vlm.image:latest")
+MULTI_IMAGE_PROMPT = os.getenv(
+    "EYEPOP_MULTI_IMAGE_PROMPT", "Describe these images together in one sentence.")
+
+
+def requires_api_key():
+    return pytest.mark.skipif(
+        not os.getenv("EYEPOP_API_KEY"),
+        reason="EYEPOP_API_KEY environment variable not set",
+    )
+
+
+def caption_pop() -> Pop:
+    return Pop(components=[
+        InferenceComponent(ability=MULTI_IMAGE_ABILITY, params={"prompt": MULTI_IMAGE_PROMPT})
+    ])
+
+
+@requires_api_key()
+def test_upload_group_single_inference_unit():
+    # A group of images is one inference unit: exactly one prediction for the
+    # whole group, not one per image.
+    with EyePopSdk.sync_worker(pop_id="transient") as endpoint:
+        endpoint.set_pop(caption_pop())
+
+        job = endpoint.upload_group([TEST_IMAGE, TEST_IMAGE, TEST_IMAGE])
+        result = job.predict()
+
+        assert result is not None
+        assert job.predict() is None
+
+
+@requires_api_key()
+@pytest.mark.asyncio
+async def test_upload_group_single_inference_unit_async():
+    async with EyePopSdk.async_worker(pop_id="transient") as endpoint:
+        await endpoint.set_pop(caption_pop())
+
+        job = await endpoint.upload_group([TEST_IMAGE, TEST_IMAGE])
+        result = await job.predict()
+
+        assert result is not None
+        assert await job.predict() is None
+
+
+@requires_api_key()
+def test_upload_stream_group_single_inference_unit():
+    with EyePopSdk.sync_worker(pop_id="transient") as endpoint:
+        endpoint.set_pop(caption_pop())
+
+        with open(TEST_IMAGE, 'rb') as a, open(TEST_IMAGE, 'rb') as b:
+            job = endpoint.upload_stream_group([a, b], mime_types=['image/jpeg', 'image/jpeg'])
+            result = job.predict()
+
+        assert result is not None
+        assert job.predict() is None
+
+
+@requires_api_key()
+def test_load_from_group_single_inference_unit():
+    with EyePopSdk.sync_worker(pop_id="transient") as endpoint:
+        endpoint.set_pop(caption_pop())
+
+        job = endpoint.load_from_group([PUBLIC_TEST_IMAGE_URL, PUBLIC_TEST_IMAGE_URL])
+        result = job.predict()
+
+        assert result is not None
+        assert job.predict() is None

--- a/tests/worker/test_endpoint_load_from_group.py
+++ b/tests/worker/test_endpoint_load_from_group.py
@@ -1,0 +1,107 @@
+import json
+import time
+
+import aiohttp
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from eyepop import EyePopSdk
+from eyepop.worker.worker_types import DEFAULT_PREDICTION_VERSION, Pop
+from tests.worker.base_endpoint_test import BaseEndpointTest
+
+
+class TestEndpointLoadFromGroup(BaseEndpointTest):
+    test_source_id = 'test_source_id'
+    test_urls = ['http://example-media.test/a.png', 'http://example-media.test/b.png']
+
+    def _setup_auth_and_pop(self, mock: aioresponses):
+        self.setup_base_mock(mock)
+        mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
+            {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+
+        def get_pop(url, **kwargs) -> CallbackResult:
+            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                return CallbackResult(status=401, reason='test auth token expired')
+            return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()}))
+
+        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}', callback=get_pop)
+
+    def _expected_group_body(self) -> str:
+        return json.dumps({
+            'sourceType': 'GROUP',
+            'sources': [{'sourceType': 'URL', 'url': url} for url in self.test_urls],
+            'version': DEFAULT_PREDICTION_VERSION,
+        })
+
+    @aioresponses()
+    def test_sync_load_from_group_ok(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        with EyePopSdk.sync_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            self.assertBaseMock(mock)
+            test_timestamp = time.time() * 1000 * 1000 * 1000
+
+            def load(url, **kwargs) -> CallbackResult:
+                if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                    return CallbackResult(status=401, reason='test auth token expired')
+                return CallbackResult(status=200, body=json.dumps(
+                    {'source_id': self.test_source_id, 'seconds': 0, 'system_timestamp': test_timestamp}))
+
+            mock.patch(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync',
+                       callback=load)
+
+            job = endpoint.load_from_group(self.test_urls)
+            result = job.predict()
+            self.assertIsNotNone(result)
+            self.assertEqual(result['source_id'], self.test_source_id)
+            self.assertIsNone(job.predict())
+
+            mock.assert_called_with(
+                f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync',
+                method='PATCH',
+                headers={
+                    'Accept': 'application/jsonl',
+                    'Content-Type': 'application/json',
+                    'Authorization': f'Bearer {self.test_access_token}'
+                },
+                data=self._expected_group_body(),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=600))
+
+    @aioresponses()
+    @pytest.mark.asyncio
+    async def test_async_load_from_group_ok(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        async with EyePopSdk.async_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            self.assertBaseMock(mock)
+            test_timestamp = time.time() * 1000 * 1000 * 1000
+
+            def load(url, **kwargs) -> CallbackResult:
+                return CallbackResult(status=200, body=json.dumps(
+                    {'source_id': self.test_source_id, 'seconds': 0, 'system_timestamp': test_timestamp}))
+
+            mock.patch(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync',
+                       callback=load)
+
+            job = await endpoint.load_from_group(self.test_urls)
+            result = await job.predict()
+            self.assertIsNotNone(result)
+            self.assertEqual(result['source_id'], self.test_source_id)
+            self.assertIsNone(await job.predict())
+
+            mock.assert_called_with(
+                f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync',
+                method='PATCH',
+                headers={
+                    'Accept': 'application/jsonl',
+                    'Content-Type': 'application/json',
+                    'Authorization': f'Bearer {self.test_access_token}'
+                },
+                data=self._expected_group_body(),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=600))

--- a/tests/worker/test_endpoint_upload_group.py
+++ b/tests/worker/test_endpoint_upload_group.py
@@ -1,0 +1,107 @@
+import json
+import time
+from importlib import resources
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+import tests
+from eyepop import EyePopSdk
+from eyepop.worker.worker_types import Pop
+from tests.worker.base_endpoint_test import BaseEndpointTest
+
+
+class TestEndpointUploadGroup(BaseEndpointTest):
+    test_source_id = 'test_group_source_id'
+    test_file = resources.files(tests) / 'test.jpg'
+
+    def _setup_auth_and_pop(self, mock: aioresponses):
+        self.setup_base_mock(mock)
+        mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
+            {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+
+        def get_pop(url, **kwargs) -> CallbackResult:
+            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                return CallbackResult(status=401, reason='test auth token expired')
+            return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()}))
+
+        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}', callback=get_pop)
+
+    @aioresponses()
+    def test_sync_upload_group_ok(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        with EyePopSdk.sync_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            self.assertBaseMock(mock)
+            test_timestamp = time.time() * 1000 * 1000 * 1000
+
+            upload_called = 0
+
+            def upload(url, **kwargs) -> CallbackResult:
+                nonlocal upload_called
+                upload_called += 1
+                if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                    return CallbackResult(status=401, reason='test auth token expired')
+                # A group is always sent as one multipart request (N 'file' parts),
+                # so it carries no top-level image Content-Type header.
+                return CallbackResult(status=200, body=json.dumps(
+                    {'source_id': self.test_source_id, 'seconds': 0, 'system_timestamp': test_timestamp}))
+
+            mock.post(
+                f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync&version=2',
+                callback=upload)
+
+            job = endpoint.upload_group([self.test_file, self.test_file])
+            result = job.predict()
+            self.assertIsNotNone(result)
+            self.assertEqual(result['source_id'], self.test_source_id)
+            self.assertIsNone(job.predict())
+            self.assertEqual(upload_called, 1)
+
+    @aioresponses()
+    @pytest.mark.asyncio
+    async def test_async_upload_group_ok(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        async with EyePopSdk.async_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            self.assertBaseMock(mock)
+            test_timestamp = time.time() * 1000 * 1000 * 1000
+
+            upload_called = 0
+
+            def upload(url, **kwargs) -> CallbackResult:
+                nonlocal upload_called
+                upload_called += 1
+                if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                    return CallbackResult(status=401, reason='test auth token expired')
+                return CallbackResult(status=200, body=json.dumps(
+                    {'source_id': self.test_source_id, 'seconds': 0, 'system_timestamp': test_timestamp}))
+
+            mock.post(
+                f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync&version=2',
+                callback=upload)
+
+            job = await endpoint.upload_group([self.test_file, self.test_file, self.test_file])
+            result = await job.predict()
+            self.assertIsNotNone(result)
+            self.assertEqual(result['source_id'], self.test_source_id)
+            self.assertIsNone(await job.predict())
+            self.assertEqual(upload_called, 1)
+
+    @aioresponses()
+    @pytest.mark.asyncio
+    async def test_empty_group_rejected(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        async with EyePopSdk.async_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            with self.assertRaises(ValueError):
+                await endpoint.upload_group([])

--- a/tests/worker/test_endpoint_upload_stream_group.py
+++ b/tests/worker/test_endpoint_upload_stream_group.py
@@ -1,0 +1,103 @@
+import io
+import json
+import time
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from eyepop import EyePopSdk
+from eyepop.worker.worker_types import Pop
+from tests.worker.base_endpoint_test import BaseEndpointTest
+
+
+class TestEndpointUploadStreamGroup(BaseEndpointTest):
+    test_source_id = 'test_stream_group_source_id'
+
+    def _setup_auth_and_pop(self, mock: aioresponses):
+        self.setup_base_mock(mock)
+        mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
+            {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+
+        def get_pop(url, **kwargs) -> CallbackResult:
+            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                return CallbackResult(status=401, reason='test auth token expired')
+            return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()}))
+
+        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}', callback=get_pop)
+
+    @staticmethod
+    def _streams(n: int):
+        return [io.BytesIO(f'fake-image-{i}'.encode()) for i in range(n)]
+
+    @aioresponses()
+    def test_sync_upload_stream_group_ok(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        with EyePopSdk.sync_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            self.assertBaseMock(mock)
+            test_timestamp = time.time() * 1000 * 1000 * 1000
+            upload_called = 0
+
+            def upload(url, **kwargs) -> CallbackResult:
+                nonlocal upload_called
+                upload_called += 1
+                if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
+                    return CallbackResult(status=401, reason='test auth token expired')
+                return CallbackResult(status=200, body=json.dumps(
+                    {'source_id': self.test_source_id, 'seconds': 0, 'system_timestamp': test_timestamp}))
+
+            mock.post(
+                f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync&version=2',
+                callback=upload)
+
+            job = endpoint.upload_stream_group(self._streams(2), mime_types=['image/jpeg', 'image/png'])
+            result = job.predict()
+            self.assertIsNotNone(result)
+            self.assertEqual(result['source_id'], self.test_source_id)
+            self.assertIsNone(job.predict())
+            self.assertEqual(upload_called, 1)
+
+    @aioresponses()
+    @pytest.mark.asyncio
+    async def test_async_upload_stream_group_ok_no_mime(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        async with EyePopSdk.async_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            self.assertBaseMock(mock)
+            test_timestamp = time.time() * 1000 * 1000 * 1000
+            upload_called = 0
+
+            def upload(url, **kwargs) -> CallbackResult:
+                nonlocal upload_called
+                upload_called += 1
+                return CallbackResult(status=200, body=json.dumps(
+                    {'source_id': self.test_source_id, 'seconds': 0, 'system_timestamp': test_timestamp}))
+
+            mock.post(
+                f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/source?mode=queue&processing=sync&version=2',
+                callback=upload)
+
+            job = await endpoint.upload_stream_group(self._streams(3))
+            result = await job.predict()
+            self.assertIsNotNone(result)
+            self.assertEqual(result['source_id'], self.test_source_id)
+            self.assertIsNone(await job.predict())
+            self.assertEqual(upload_called, 1)
+
+    @aioresponses()
+    @pytest.mark.asyncio
+    async def test_mime_types_length_mismatch_rejected(self, mock: aioresponses):
+        self._setup_auth_and_pop(mock)
+        async with EyePopSdk.async_worker(
+                eyepop_url=self.test_eyepop_url,
+                secret_key=self.test_eyepop_secret_key,
+                pop_id=self.test_eyepop_pop_id,
+        ) as endpoint:
+            with self.assertRaises(ValueError):
+                await endpoint.upload_stream_group(self._streams(2), mime_types=['image/jpeg'])


### PR DESCRIPTION
## What

Adds client-side support for **multi-image sources** (server `SOURCE_GROUP`) to the Python SDK, under [VREE-288](https://eyepop.atlassian.net/browse/VREE-288) / epic VREE-284. A *group* is a set of images submitted as **one** source and run as a **single inference unit** (one prediction stream) — distinct from the existing independent `SOURCE_LIST`.

This PR delivers **slice 01: `upload_group` (local file paths)** — the tracer-bullet path that works against the *current* merged server (eyepop-instance #225) with no server change.

## Changes

- **`_UploadGroupJob`** (`worker_jobs.py`): one multipart POST with an ordered `file` part per location (part order = canonical image order). Each part's `Content-Type` is derived from its file extension, so members arrive `image/*` and pass current server validation without a caller-supplied mime. Group-level `params` / `roi` / `media_cache_seconds`; no `video_mode` / `motion_detect` / `fps` (group is still images). Empty-group guard.
- **`WorkerEndpoint.upload_group`** + **`SyncWorkerEndpoint.upload_group`**.
- **Tests**: sync, async, and empty-group rejection. Existing single-image `upload` / `upload_stream` behavior unchanged.
- **Planning docs** under `docs/initiatives/multi-image-sources/` (PRD + sliced issues) and `docs/CONTEXT.md` vocabulary, plus a local issue-tracker contract.

## Validation

- ✅ ruff clean on changed files
- ✅ full unit suite: **133 passed**
- ℹ️ basedpyright adds one `reportIncompatibleMethodOverride` of the same pattern every existing job class uses (`_do_execute_job` narrows `ClientSession`→`WorkerClientSession`); consistent with the file's baseline.

## Not in this PR (tracked)

- **Staging integration test** for `upload_group` — needs a multi-image-capable pop (slice 01 remains `in_progress` for this).
- **Slice 02** (`upload_stream_group` + `load_from_group`) — blocked on [VREE-294](https://eyepop.atlassian.net/browse/VREE-294) (relax `SOURCE_GROUP` member content-type server-side).
- **Slice 03** — docs/example + mime-asymmetry ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VREE-288]: https://eyepop.atlassian.net/browse/VREE-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VREE-294]: https://eyepop.atlassian.net/browse/VREE-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for image groups—submit multiple images (up to 16) as a single inference unit to receive one prediction for the combined set.
  * New methods available for local files, in-memory streams, and remote URLs.

* **Documentation**
  * Updated README with guidance on image group submission and usage examples.

* **Tests**
  * Added comprehensive test coverage for image group functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->