### PR TITLE
[SDK]: Start transient pipelines with requested pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Scheduled sessions smoke workflow for validating transient SDK inference against production with optional Slack status alerts and selectable SDK package versions.
 - `session_name` support on worker session creation, also configurable via `EYEPOP_SESSION_NAME`.
+- `pop` support on worker session creation so transient compute sessions can be scheduled before starting a worker pipeline.
 
 ### Fixed
 - Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -88,6 +88,8 @@ async def fetch_new_compute_session(
                 body["pipeline_image"] = compute_ctx.pipeline_image
             if compute_ctx.pipeline_version:
                 body["pipeline_version"] = compute_ctx.pipeline_version
+            if compute_ctx.pop is not None:
+                body["pop"] = compute_ctx.pop
 
             async with client_session.post(
                 f'{sessions_url}?wait=true',

--- a/eyepop/compute/context.py
+++ b/eyepop/compute/context.py
@@ -1,5 +1,6 @@
 import os
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -43,6 +44,10 @@ class ComputeContext(BaseModel):
     pipeline_version: str = Field(
         description="Custom Docker image tag for the worker pipeline",
         default_factory=lambda: os.getenv("EYEPOP_PIPELINE_VERSION", "")
+    )
+    pop: dict[str, Any] | None = Field(
+        description="Pop definition used by compute API for session scheduling",
+        default=None
     )
 
 

--- a/eyepop/eyepopsdk.py
+++ b/eyepop/eyepopsdk.py
@@ -8,6 +8,7 @@ from eyepop.data.data_endpoint import DataEndpoint
 from eyepop.data.data_syncify import SyncDataEndpoint
 from eyepop.worker.worker_endpoint import WorkerEndpoint
 from eyepop.worker.worker_syncify import SyncWorkerEndpoint
+from eyepop.worker.worker_types import Pop
 
 log = logging.getLogger('eyepop')
 log.debug(f"EyePop SDK v{__version__} initializing...")
@@ -34,6 +35,7 @@ class EyePopSdk:
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
             session_name: str | None = None,
+            pop: Pop | dict[str, object] | None = None,
     ) -> WorkerEndpoint | SyncWorkerEndpoint:
         if is_async:
             return EyePopSdk.async_worker(
@@ -52,6 +54,7 @@ class EyePopSdk:
                 pipeline_image=pipeline_image,
                 pipeline_version=pipeline_version,
                 session_name=session_name,
+                pop=pop,
             )
         else:
             return EyePopSdk.sync_worker(
@@ -70,6 +73,7 @@ class EyePopSdk:
                 pipeline_image=pipeline_image,
                 pipeline_version=pipeline_version,
                 session_name=session_name,
+                pop=pop,
             )
 
     @staticmethod
@@ -89,6 +93,7 @@ class EyePopSdk:
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
             session_name: str | None = None,
+            pop: Pop | dict[str, object] | None = None,
     ) -> SyncWorkerEndpoint:
         endpoint = EyePopSdk.async_worker(
             pop_id=pop_id,
@@ -106,6 +111,7 @@ class EyePopSdk:
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
             session_name=session_name,
+            pop=pop,
         )
         return SyncWorkerEndpoint(endpoint)
 
@@ -126,6 +132,7 @@ class EyePopSdk:
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
             session_name: str | None = None,
+            pop: Pop | dict[str, object] | None = None,
     ) -> WorkerEndpoint:
         if is_local_mode is None:
             local_mode_env = os.getenv("EYEPOP_LOCAL_MODE", "")
@@ -194,6 +201,7 @@ class EyePopSdk:
             pipeline_image=pipeline_image,
             pipeline_version=pipeline_version,
             session_name=session_name,
+            pop=pop,
         )
         return endpoint
 

--- a/eyepop/jobs.py
+++ b/eyepop/jobs.py
@@ -47,11 +47,12 @@ class Job:
 
     def __init__(self,
                  session: ClientSession,
-                 on_ready: Callable[["Job"], None] | None,
+                 on_ready: Callable[["Job"], Any] | None,
                  callback: JobStateCallback | None = None):
         self.on_ready = on_ready
         self._session = session
-        self._response = None
+        self._response: Any = None
+        self._callback: JobStateCallback
         self._queue = asyncio.Queue(maxsize=128)
         if callback is not None:
             self._callback = callback
@@ -64,7 +65,9 @@ class Job:
         self._callback.finalized(self)
 
     async def push_message(self, message: dict[str, Any]):
-        await self._queue.put(message)
+        queue = self._queue
+        if queue is not None:
+            await queue.put(message)
 
     async def pop_result(self) -> Any:
         queue = self._queue
@@ -92,6 +95,8 @@ class Job:
 
     async def execute(self):
         queue = self._queue
+        if queue is None:
+            return
         session = self._session
 
         self._callback.started(self)
@@ -115,6 +120,5 @@ class Job:
             if self.on_ready is not None:
                 await self.on_ready(self)
 
-    async def _do_execute_job(self, queue: Queue, session: ClientSession):
+    async def _do_execute_job(self, queue: Queue, session: Any):
         raise NotImplementedError("can't execute abstract jobs")
-

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -1,7 +1,8 @@
+import asyncio
 import logging
 import time
 from io import StringIO
-from typing import Any, AsyncIterable, BinaryIO, Callable, Iterable
+from typing import Any, AsyncIterable, BinaryIO, Callable
 from urllib.parse import urljoin
 
 import aiohttp
@@ -80,7 +81,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         self.auto_start = auto_start
         self.stop_jobs = stop_jobs
         self.dataset_uuid = dataset_uuid
-        self.pop = pop if isinstance(pop, Pop) else Pop(**pop) if pop is not None else Pop(components=[])
+        self.pop = pop if isinstance(pop, Pop) else Pop(**pop) if pop is not None else None
 
         if self.compute_ctx:
             if pipeline_image:
@@ -95,6 +96,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             self.is_dev_mode = True
 
         self.worker_config = None
+        self._pipeline_create_lock = asyncio.Lock()
         self.last_fetch_config_success_time = None
         self.last_fetch_config_error = None
         self.last_fetch_config_error_time = None
@@ -215,7 +217,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             async with self.client_session.patch(stop_jobs_url, headers=headers, json=body) as response:
                 pass
 
-        if self.is_dev_mode and self.pop is None:
+        if self.is_dev_mode and self.pop is None and self._has_pipeline_id():
             get_url = await self.dev_mode_pipeline_base_url()
             headers = {}
             authorization_header = await self._authorization_header()
@@ -260,7 +262,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if self.worker_config is None:
             await self._reconnect()
         if self.is_dev_mode and not self._has_pipeline_id():
-            return await self._create_pipeline()
+            return await self._ensure_pipeline_started()
         response = await self.pipeline_patch('pop', content_type='application/json',
                                              data=pop.model_dump_json())
         return response
@@ -303,7 +305,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
 
     async def upload_stream(
             self,
-            stream: BinaryIO | AsyncIterable[bytes] | Iterable[bytes],
+            stream: BinaryIO | AsyncIterable[bytes],
             mime_type: str,
             video_mode: VideoMode | None = None,
             is_live: bool | None = None,
@@ -495,7 +497,10 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
     async def _ensure_pipeline_started(self) -> dict[str, Any] | None:
         if self._has_pipeline_id():
             return None
-        return await self._create_pipeline()
+        async with self._pipeline_create_lock:
+            if self._has_pipeline_id():
+                return None
+            return await self._create_pipeline()
 
     async def _create_pipeline(self) -> dict[str, Any]:
         assert self.client_session is not None

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -65,6 +65,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             pipeline_image: str | None = None,
             pipeline_version: str | None = None,
             session_name: str | None = None,
+            pop: Pop | dict[str, Any] | None = None,
     ):
         super().__init__(
             secret_key=secret_key,
@@ -79,6 +80,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         self.auto_start = auto_start
         self.stop_jobs = stop_jobs
         self.dataset_uuid = dataset_uuid
+        self.pop = pop if isinstance(pop, Pop) else Pop(**pop) if pop is not None else Pop(components=[])
 
         if self.compute_ctx:
             if pipeline_image:
@@ -87,6 +89,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 self.compute_ctx.pipeline_version = pipeline_version
             if session_name:
                 self.compute_ctx.session_name = session_name
+            self.compute_ctx.pop = self.pop.model_dump() if self.pop is not None else None
             self.is_dev_mode = not bool(session_uuid)
         else:
             self.is_dev_mode = True
@@ -95,9 +98,6 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         self.last_fetch_config_success_time = None
         self.last_fetch_config_error = None
         self.last_fetch_config_error_time = None
-
-        # new way
-        self.pop = Pop(components=[])
 
         self.add_retry_handler(404, self._retry_404)
 
@@ -114,11 +114,13 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if timeout is not None:
             client_timeout = aiohttp.ClientTimeout(total=timeout)
         if (self.is_dev_mode and self.pop_id == 'transient'
-                and self.worker_config is not None and self.worker_config.get('pipeline_id') is not None
+                and self._has_pipeline_id()
                 and self.client_session is not None):
+            worker_config = self.worker_config
+            assert worker_config is not None
             try:
                 base_url = await self.dev_mode_base_url()
-                delete_pipeline_url = f'{base_url}/pipelines/{self.worker_config["pipeline_id"]}'
+                delete_pipeline_url = f'{base_url}/pipelines/{worker_config["pipeline_id"]}'
                 headers = {}
                 authorization_header = await self._authorization_header()
                 if authorization_header is not None:
@@ -127,7 +129,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             except Exception as e:
                 log.exception(e, exc_info=True)
             finally:
-                del self.worker_config["pipeline_id"]
+                del worker_config["pipeline_id"]
 
     async def _reconnect(self):
         # Narrow Optional[ClientSession] — _reconnect is only called after connect()
@@ -200,44 +202,10 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if self.compute_ctx:
             log_requests.debug(f'Compute session: {self.compute_ctx.session_uuid}')
 
-        base_url = await self.dev_mode_base_url()
-
         if self.worker_config.get('status') == 'active_prod':
             self.is_dev_mode = False
 
-        if self.is_dev_mode:
-            start_pipeline_url = f'{base_url}/pipelines'
-            body = {
-                "pop": self.pop.model_dump() if self.pop else {},
-                "source": {
-                    "sourceType": "NONE"
-                },
-                "idleTimeoutSeconds": 300,
-                "logging": ["out_meta"],
-                "videoOutput": "no_output",
-            }
-            if self.dataset_uuid is not None:
-                body["datasetUuid"] = self.dataset_uuid
-
-            headers = {}
-            authorization_header = await self._authorization_header()
-            if authorization_header is not None:
-                headers['Authorization'] = authorization_header
-            async with self.client_session.post(start_pipeline_url, headers=headers, json=body) as response:
-                response_json = await response.json()
-            self.worker_config['pipeline_id'] = response_json['id']
-
-            if self.compute_ctx:
-                self.compute_ctx.pipeline_uuid = response_json['id']
-                log.debug(f"Created pipeline with ID: {response_json['id']}")
-
-            has_base_url = ('base_url' in self.worker_config and self.worker_config['base_url'] is not None) or \
-                          ('session_endpoint' in self.worker_config and self.worker_config['session_endpoint'] is not None)
-            has_pipeline_id = self.worker_config.get('pipeline_id') is not None
-            if not has_base_url or not has_pipeline_id:
-                raise PopNotStartedException(pop_id=self.pop_id)
-
-        if self.is_dev_mode and self.stop_jobs:
+        if self.is_dev_mode and self.stop_jobs and self._has_pipeline_id():
             stop_jobs_url = f'{await self.dev_mode_pipeline_base_url()}/source?mode=preempt&processing=sync'
             body = {'sourceType': 'NONE'}
             headers = {}
@@ -262,24 +230,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                     self.pop = Pop(**pop_as_dict)
             log.debug('current pop is %s', self.pop)
 
-        if self.is_dev_mode:
-            if 'session_endpoint' in self.worker_config:
-                base_url = self.worker_config['session_endpoint'].rstrip("/")
-            else:
-                base_url = urljoin(self.eyepop_url, self.worker_config['base_url']).rstrip("/")
-            endpoint = {'base_url': base_url, 'pipeline_id': self.worker_config['pipeline_id']}
-            self.load_balancer = EndpointLoadBalancer([endpoint])
-            log.debug(f"Initialized load balancer with endpoint: {endpoint}")
-        else:
-            if 'session_endpoint' in self.worker_config:
-                base_url = self.worker_config['session_endpoint'].rstrip("/")
-                endpoint = {'base_url': base_url, 'pipeline_id': self.worker_config['pipeline_id']}
-                self.load_balancer = EndpointLoadBalancer([endpoint])
-                log.debug(f"Initialized load balancer with endpoint: {endpoint}")
-            else:
-                self.load_balancer = EndpointLoadBalancer(self.worker_config['endpoints'])
-                log.debug(f"Initialized load balancer with endpoints: {self.worker_config['endpoints']}")
-
+        self._configure_load_balancer()
 
     # Parent returns dict | None — must match and guard against None before subscripting
     async def session(self) -> dict | None:
@@ -292,7 +243,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 session['baseUrl'] = self.worker_config['session_endpoint']
             elif 'base_url' in self.worker_config:
                 session['baseUrl'] = self.worker_config['base_url']
-            session['pipelineId'] = self.worker_config['pipeline_id']
+            session['pipelineId'] = self.worker_config.get('pipeline_id')
         return session
 
     async def get_pop(self) -> Pop | None:
@@ -301,9 +252,17 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
     async def set_pop(self, pop: Pop):
         if not self.is_dev_mode:
             raise PopConfigurationException(self.pop_id, 'set_pop not supported in production mode')
+        self.pop = pop
+        if self.compute_ctx:
+            self.compute_ctx.pop = pop.model_dump()
+        if self.client_session is None:
+            return {"pop": pop.model_dump()}
+        if self.worker_config is None:
+            await self._reconnect()
+        if self.is_dev_mode and not self._has_pipeline_id():
+            return await self._create_pipeline()
         response = await self.pipeline_patch('pop', content_type='application/json',
                                              data=pop.model_dump_json())
-        self.pop = pop
         return response
 
     async def dev_mode_pipeline_base_url(self) -> str:
@@ -313,6 +272,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         base_url = await self.dev_mode_base_url()
         if self.worker_config is None:
             raise PopNotStartedException(pop_id=self.pop_id)
+        if not self._has_pipeline_id():
+            await self._ensure_pipeline_started()
         return f'{base_url}/pipelines/{self.worker_config["pipeline_id"]}'
 
     async def upload(
@@ -514,6 +475,83 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             return self.worker_config['session_endpoint'].rstrip("/")
         return urljoin(self.eyepop_url, self.worker_config['base_url']).rstrip("/")
 
+    def _has_pipeline_id(self) -> bool:
+        return self.worker_config is not None and bool(self.worker_config.get('pipeline_id'))
+
+    def _pipeline_create_body(self) -> dict[str, Any]:
+        body = {
+            "pop": self.pop.model_dump() if self.pop else {},
+            "source": {
+                "sourceType": "NONE"
+            },
+            "idleTimeoutSeconds": 300,
+            "logging": ["out_meta"],
+            "videoOutput": "no_output",
+        }
+        if self.dataset_uuid is not None:
+            body["datasetUuid"] = self.dataset_uuid
+        return body
+
+    async def _ensure_pipeline_started(self) -> dict[str, Any] | None:
+        if self._has_pipeline_id():
+            return None
+        return await self._create_pipeline()
+
+    async def _create_pipeline(self) -> dict[str, Any]:
+        assert self.client_session is not None
+        if self.worker_config is None:
+            await self._reconnect()
+        if self.worker_config is None:
+            raise PopNotStartedException(pop_id=self.pop_id)
+
+        start_pipeline_url = f'{await self.dev_mode_base_url()}/pipelines'
+        headers = {}
+        authorization_header = await self._authorization_header()
+        if authorization_header is not None:
+            headers['Authorization'] = authorization_header
+
+        async with self.client_session.post(
+                start_pipeline_url,
+                headers=headers,
+                json=self._pipeline_create_body(),
+        ) as response:
+            response.raise_for_status()
+            response_json = await response.json()
+
+        self.worker_config['pipeline_id'] = response_json['id']
+        if self.compute_ctx:
+            self.compute_ctx.pipeline_uuid = response_json['id']
+            self.compute_ctx.pipeline_id = response_json['id']
+            log.debug(f"Created pipeline with ID: {response_json['id']}")
+
+        self._configure_load_balancer()
+        return response_json
+
+    def _configure_load_balancer(self):
+        if self.worker_config is None:
+            return
+
+        if self.is_dev_mode:
+            if not self._has_pipeline_id():
+                self.load_balancer = EndpointLoadBalancer([])
+                return
+            if 'session_endpoint' in self.worker_config:
+                base_url = self.worker_config['session_endpoint'].rstrip("/")
+            else:
+                base_url = urljoin(self.eyepop_url, self.worker_config['base_url']).rstrip("/")
+            endpoint = {'base_url': base_url, 'pipeline_id': self.worker_config['pipeline_id']}
+            self.load_balancer = EndpointLoadBalancer([endpoint])
+            log.debug(f"Initialized load balancer with endpoint: {endpoint}")
+        else:
+            if 'session_endpoint' in self.worker_config:
+                base_url = self.worker_config['session_endpoint'].rstrip("/")
+                endpoint = {'base_url': base_url, 'pipeline_id': self.worker_config['pipeline_id']}
+                self.load_balancer = EndpointLoadBalancer([endpoint])
+                log.debug(f"Initialized load balancer with endpoint: {endpoint}")
+            else:
+                self.load_balancer = EndpointLoadBalancer(self.worker_config['endpoints'])
+                log.debug(f"Initialized load balancer with endpoints: {self.worker_config['endpoints']}")
+
     #
     # Implements: _WorkerClientSession
     # Return types changed from _RequestContextManager to ClientResponse — these methods
@@ -561,6 +599,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         while time.time() - start_time < settings.max_retry_time_secs:
             if self.worker_config is None:
                 await self._reconnect()
+            if self.is_dev_mode and not self._has_pipeline_id():
+                await self._ensure_pipeline_started()
 
             entry = self.load_balancer.next_entry(settings.max_retry_time_secs + 1)
             log.debug(f"Load balancer entry: {entry}")

--- a/eyepop/worker/worker_jobs.py
+++ b/eyepop/worker/worker_jobs.py
@@ -3,7 +3,7 @@ import json
 import logging
 import mimetypes
 from asyncio import Queue
-from typing import Any, AsyncIterable, BinaryIO, Callable
+from typing import Any, AsyncIterable, BinaryIO, Callable, Iterable, cast
 from urllib.parse import urlencode
 
 import aiohttp
@@ -44,7 +44,7 @@ class WorkerJob(Job):
             callback: JobStateCallback | None = None,
             version: PredictionVersion = DEFAULT_PREDICTION_VERSION,
     ):
-        super().__init__(session, on_ready, callback)
+        super().__init__(session, cast(Callable[[Job], Any] | None, on_ready), callback)
         self._component_params = component_params
         self._motion_detect = motion_detect
         self._roi = roi
@@ -99,10 +99,10 @@ class _UploadSource:
     mime_type may be None when it cannot be derived (a raw stream group with no
     caller-supplied mime); the server no longer requires a per-member content type.
     """
-    open_stream: Callable[[], BinaryIO  | AsyncIterable[bytes]]
+    open_stream: Callable[[], BinaryIO | AsyncIterable[bytes] | Iterable[bytes]]
     mime_type: str | None
 
-    def __init__(self, open_stream: Callable[[], BinaryIO  | AsyncIterable[bytes]], mime_type: str | None):
+    def __init__(self, open_stream: Callable[[], BinaryIO | AsyncIterable[bytes] | Iterable[bytes]], mime_type: str | None):
         self.open_stream = open_stream
         self.mime_type = mime_type
 
@@ -273,7 +273,7 @@ def _file_stream_opener(location: str) -> Callable[[], BinaryIO]:
     return opener
 
 
-def _stream_opener(stream: BinaryIO) -> Callable[[], BinaryIO]:
+def _stream_opener(stream: BinaryIO | AsyncIterable[bytes] | Iterable[bytes]) -> Callable[[], BinaryIO | AsyncIterable[bytes] | Iterable[bytes]]:
     def opener():
         return stream
     return opener
@@ -317,7 +317,7 @@ class _UploadFileJob(_UploadJob):
 class _UploadStreamJob(_UploadJob):
     def __init__(
             self,
-            stream: BinaryIO | AsyncIterable[bytes],
+            stream: BinaryIO | AsyncIterable[bytes] | Iterable[bytes],
             mime_type: str,
             video_mode: VideoMode | None,
             is_live: bool | None,
@@ -572,4 +572,3 @@ class _LoadFromAssetUuidJob(WorkerJob):
                                                       content_type='application/json',
                                                       timeout=self.timeouts)
         await self._do_read_response(queue)
-

--- a/eyepop/worker/worker_jobs.py
+++ b/eyepop/worker/worker_jobs.py
@@ -3,7 +3,7 @@ import json
 import logging
 import mimetypes
 from asyncio import Queue
-from typing import Any, AsyncIterable, BinaryIO, Callable, Iterable, cast
+from typing import Any, AsyncIterable, BinaryIO, Callable, cast
 from urllib.parse import urlencode
 
 import aiohttp
@@ -99,10 +99,10 @@ class _UploadSource:
     mime_type may be None when it cannot be derived (a raw stream group with no
     caller-supplied mime); the server no longer requires a per-member content type.
     """
-    open_stream: Callable[[], BinaryIO | AsyncIterable[bytes] | Iterable[bytes]]
+    open_stream: Callable[[], BinaryIO | AsyncIterable[bytes]]
     mime_type: str | None
 
-    def __init__(self, open_stream: Callable[[], BinaryIO | AsyncIterable[bytes] | Iterable[bytes]], mime_type: str | None):
+    def __init__(self, open_stream: Callable[[], BinaryIO | AsyncIterable[bytes]], mime_type: str | None):
         self.open_stream = open_stream
         self.mime_type = mime_type
 
@@ -273,7 +273,7 @@ def _file_stream_opener(location: str) -> Callable[[], BinaryIO]:
     return opener
 
 
-def _stream_opener(stream: BinaryIO | AsyncIterable[bytes] | Iterable[bytes]) -> Callable[[], BinaryIO | AsyncIterable[bytes] | Iterable[bytes]]:
+def _stream_opener(stream: BinaryIO | AsyncIterable[bytes]) -> Callable[[], BinaryIO | AsyncIterable[bytes]]:
     def opener():
         return stream
     return opener
@@ -317,7 +317,7 @@ class _UploadFileJob(_UploadJob):
 class _UploadStreamJob(_UploadJob):
     def __init__(
             self,
-            stream: BinaryIO | AsyncIterable[bytes] | Iterable[bytes],
+            stream: BinaryIO | AsyncIterable[bytes],
             mime_type: str,
             video_mode: VideoMode | None,
             is_live: bool | None,

--- a/eyepop/worker/worker_syncify.py
+++ b/eyepop/worker/worker_syncify.py
@@ -17,7 +17,7 @@ class SyncWorkerJob:
         self.job = job
         self.event_loop = event_loop
 
-    def predict(self) -> dict:
+    def predict(self) -> dict | None:
         prediction = run_coro_thread_save(self.event_loop, self.job.predict())
         return prediction
 
@@ -207,5 +207,4 @@ class SyncWorkerEndpoint(SyncEndpoint):
 
     def set_pop(self, pop: Pop) -> dict:
         return run_coro_thread_save(self.event_loop, self.endpoint.set_pop(pop))
-
 

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -1,7 +1,9 @@
+import json
 from unittest.mock import patch
 
 import aiohttp
 import pytest
+from aioresponses import CallbackResult
 
 from eyepop.compute import ComputeContext
 from eyepop.compute.api import fetch_new_compute_session, fetch_session_endpoint
@@ -68,6 +70,36 @@ async def test_creates_session_when_none_exists(mock_compute_config, aioresponse
 
     assert result.session_endpoint == "https://pipeline.example.com"
     assert result.m2m_access_token == "jwt-token-123"
+
+
+@pytest.mark.asyncio
+async def test_creates_session_with_pop_for_scheduling(aioresponses):
+    pop = {"components": [{"type": "inference", "model": "yolo"}], "postTransform": None}
+    ctx = ComputeContext(
+        compute_url="https://compute.staging.eyepop.xyz",
+        api_key="test-api-key",
+        pop=pop,
+    )
+    captured_body = {}
+
+    def create_session(url, **kwargs):
+        captured_body.update(kwargs["json"])
+        return CallbackResult(body=json.dumps(MOCK_SESSION_RESPONSE), status=200)
+
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[],
+        status=200
+    )
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        callback=create_session
+    )
+
+    async with aiohttp.ClientSession() as session:
+        await fetch_new_compute_session(ctx, session)
+
+    assert captured_body["pop"] == pop
 
 
 @pytest.mark.asyncio

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -103,6 +103,30 @@ async def test_creates_session_with_pop_for_scheduling(aioresponses):
 
 
 @pytest.mark.asyncio
+async def test_creates_session_without_pop_when_unset(mock_compute_config, aioresponses):
+    captured_body = {}
+
+    def create_session(url, **kwargs):
+        captured_body.update(kwargs.get("json") or {})
+        return CallbackResult(body=json.dumps(MOCK_SESSION_RESPONSE), status=200)
+
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[],
+        status=200
+    )
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        callback=create_session
+    )
+
+    async with aiohttp.ClientSession() as session:
+        await fetch_new_compute_session(mock_compute_config, session)
+
+    assert "pop" not in captured_body
+
+
+@pytest.mark.asyncio
 async def test_creates_session_when_get_returns_404(mock_compute_config, aioresponses):
     aioresponses.get(
         "https://compute.staging.eyepop.xyz/v1/sessions",

--- a/tests/worker/base_endpoint_test.py
+++ b/tests/worker/base_endpoint_test.py
@@ -4,8 +4,6 @@ import unittest
 
 from aioresponses import CallbackResult, aioresponses
 
-from eyepop.worker.worker_types import Pop
-
 
 class BaseEndpointTest(unittest.IsolatedAsyncioTestCase):
 
@@ -120,7 +118,7 @@ class BaseEndpointTest(unittest.IsolatedAsyncioTestCase):
                 headers={'Authorization': f'Bearer {provided_access_token}'},
                 data=None,
                 json={
-                    "pop": Pop(components=[]).model_dump(),
+                    "pop": {},
                     "source": {
                         "sourceType": "NONE",
                     },

--- a/tests/worker/base_endpoint_test.py
+++ b/tests/worker/base_endpoint_test.py
@@ -100,7 +100,8 @@ class BaseEndpointTest(unittest.IsolatedAsyncioTestCase):
             is_transient: bool = False,
             status: str = 'active_dev',
             num_endpoints: int = 1,
-            provided_access_token: str | None = None
+            provided_access_token: str | None = None,
+            expect_pipeline_started: bool = True,
     ):
         if provided_access_token is None:
             provided_access_token = self.test_access_token
@@ -110,6 +111,8 @@ class BaseEndpointTest(unittest.IsolatedAsyncioTestCase):
             mock.assert_called_with(f'{self.test_eyepop_url}/workers/config',
                                     method='GET',
                                     headers={'Authorization': f'Bearer {provided_access_token}'})
+            if not expect_pipeline_started:
+                return
             start_url = f'{self.test_worker_url}/pipelines'
             mock.assert_called_with(
                 start_url,

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -1,11 +1,14 @@
+import asyncio
 import json
 import unittest
 import uuid
+from types import MethodType
 
 from aiohttp import ClientResponseError
 from aioresponses import CallbackResult, aioresponses
 
 from eyepop import EyePopSdk
+from eyepop.worker.worker_endpoint import WorkerEndpoint
 from eyepop.worker.worker_types import Pop
 from tests.worker.base_endpoint_test import BaseEndpointTest
 
@@ -26,6 +29,29 @@ class TestEndpointConnect(BaseEndpointTest):
 
         self.assertIsNotNone(endpoint.compute_ctx)
         self.assertEqual(endpoint.compute_ctx.session_name, "sessions-smoke-123")
+
+    async def test_ensure_pipeline_started_serializes_concurrent_creation(self):
+        endpoint = object.__new__(WorkerEndpoint)
+        endpoint.worker_config = {}
+        endpoint._pipeline_create_lock = asyncio.Lock()
+        create_calls = 0
+
+        async def create_pipeline(self):
+            nonlocal create_calls
+            create_calls += 1
+            await asyncio.sleep(0)
+            self.worker_config["pipeline_id"] = "created-pipeline"
+            return {"id": "created-pipeline"}
+
+        endpoint._create_pipeline = MethodType(create_pipeline, endpoint)
+
+        await asyncio.gather(
+            endpoint._ensure_pipeline_started(),
+            endpoint._ensure_pipeline_started(),
+        )
+
+        self.assertEqual(create_calls, 1)
+        self.assertEqual(endpoint.worker_config["pipeline_id"], "created-pipeline")
 
     @aioresponses()
     def test_connect_ok(self, mock: aioresponses):

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -107,7 +107,7 @@ class TestEndpointConnect(BaseEndpointTest):
         finally:
             endpoint.disconnect()
 
-        self.assertBaseMock(mock, is_transient=True)
+        self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):

--- a/tests/worker/test_endpoint_pop.py
+++ b/tests/worker/test_endpoint_pop.py
@@ -61,7 +61,7 @@ class TestEndpointPop(BaseEndpointTest):
                 pop_id="transient",
         ) as endpoint:
             cur_pop = endpoint.get_pop()
-        self.assertEqual(cur_pop, Pop(components=[]))
+        self.assertIsNone(cur_pop)
         self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     @aioresponses()
@@ -110,7 +110,7 @@ class TestEndpointPop(BaseEndpointTest):
                 pop_id="transient",
         ) as endpoint:
             cur_pop = await endpoint.get_pop()
-        self.assertEqual(cur_pop, Pop(components=[]))
+        self.assertIsNone(cur_pop)
         self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     

--- a/tests/worker/test_endpoint_pop.py
+++ b/tests/worker/test_endpoint_pop.py
@@ -21,6 +21,24 @@ class TestEndpointPop(BaseEndpointTest):
     )
 
     current_pop: Pop | None = None
+
+    def assert_pipeline_started_with_pop(self, mock: aioresponses, pop: Pop):
+        mock.assert_called_with(
+            f'{self.test_worker_url}/pipelines',
+            method='POST',
+            headers={'Authorization': f'Bearer {self.test_access_token}'},
+            data=None,
+            json={
+                "pop": pop.model_dump(),
+                "source": {
+                    "sourceType": "NONE",
+                },
+                "idleTimeoutSeconds": 300,
+                "logging": ["out_meta"],
+                "videoOutput": "no_output"
+            }
+        )
+
     @aioresponses()
     def test_sync_get_pop(self, mock: aioresponses):
 
@@ -44,7 +62,7 @@ class TestEndpointPop(BaseEndpointTest):
         ) as endpoint:
             cur_pop = endpoint.get_pop()
         self.assertEqual(cur_pop, Pop(components=[]))
-        self.assertBaseMock(mock, is_transient=True)
+        self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     @aioresponses()
     def test_sync_set_pop(self, mock: aioresponses):
@@ -65,20 +83,9 @@ class TestEndpointPop(BaseEndpointTest):
                 secret_key=self.test_eyepop_secret_key,
                 pop_id="transient",
         ) as endpoint:
-            def set_pop(url, **kwargs) -> CallbackResult:
-                if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                    return CallbackResult(status=401, reason='test auth token expired')
-                else:
-                    self.current_pop = Pop(**json.loads(kwargs['data']))
-                    return CallbackResult(status=204)
-
-            mock.patch(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/pop',
-                       callback=set_pop)
-            
             endpoint.set_pop(self.test_new_pop)
             self.assertEqual(endpoint.get_pop(), self.test_new_pop)
-            self.assertEqual(self.current_pop, self.test_new_pop)
-        self.assertBaseMock(mock, is_transient=True)
+            self.assert_pipeline_started_with_pop(mock, self.test_new_pop)
 
 
     @aioresponses()
@@ -104,7 +111,7 @@ class TestEndpointPop(BaseEndpointTest):
         ) as endpoint:
             cur_pop = await endpoint.get_pop()
         self.assertEqual(cur_pop, Pop(components=[]))
-        self.assertBaseMock(mock, is_transient=True)
+        self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     
     @aioresponses()
@@ -128,21 +135,6 @@ class TestEndpointPop(BaseEndpointTest):
                 secret_key=self.test_eyepop_secret_key,
                 pop_id="transient",
         ) as endpoint:
-            def set_pop(url, **kwargs) -> CallbackResult:
-                if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                    return CallbackResult(status=401, reason='test auth token expired')
-                elif kwargs['headers']['Content-Type'] != 'application/json':
-                    return CallbackResult(status=400, reason='unsupported content type')
-                else:
-                    self.current_pop = Pop(**json.loads(kwargs['data']))
-                    return CallbackResult(status=204)
-
-            mock.patch(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}/pop',
-                       callback=set_pop)
-            
             await endpoint.set_pop(self.test_new_pop)
             self.assertEqual(await endpoint.get_pop(), self.test_new_pop)
-            self.assertEqual(self.current_pop, self.test_new_pop)
-
-        self.assertBaseMock(mock, is_transient=True)
-
+            self.assert_pipeline_started_with_pop(mock, self.test_new_pop)


### PR DESCRIPTION
## Summary
- Send the worker pop definition in transient compute session creation so compute-api can schedule the session from the requested pop.
- Stop creating an empty transient pipeline on worker connect; lazily create the worker pipeline with the current pop on first pipeline-bound call or set_pop.
- Add small typecheck cleanups needed by the touched worker path.

## Changes
- Adds ComputeContext.pop and forwards it to POST /v1/sessions?wait=true.
- Adds optional pop argument to worker factory methods.
- Refactors WorkerEndpoint to lazily create dev-mode pipelines and configure load balancing after creation.
- Updates tests for connect/get-pop no longer creating a pipeline, and set_pop creating the pipeline with the requested pop.

## Test plan
- [x] task check
- [x] uv run --extra test pytest tests/test_compute_api.py tests/worker/test_endpoint_connect.py tests/worker/test_endpoint_pop.py -q
- [x] uv run --extra test pytest tests/worker -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker session creation now supports optional `pop` scheduling data to help with pipeline placement.
  * Worker SDK APIs for creating workers now accept optional `pop` payloads.

* **Bug Fixes**
  * Session requests no longer include `pop` when it isn’t provided.
  * Improved robustness of job execution/message queuing around cancelled or drained queues.
  * Refined dev-mode pipeline start/reconnect behavior for transient and POP-driven flows.

* **Tests**
  * Added/updated coverage for forwarding `pop` in compute session requests, pipeline start concurrency, and POP get/set behaviors.

* **Documentation**
  * Updated the Unreleased changelog to mention `pop` support for transient compute session scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->