### PR TITLE
[AWSU-204]: Recheck transient scheduling when setting pop

### DIFF
--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -16,7 +16,7 @@ log = logging.getLogger("eyepop.compute")
 async def fetch_session_endpoint(
     compute_ctx: ComputeContext,
     client_session: aiohttp.ClientSession,
-    permanent_session_uuid: str | None
+    permanent_session_uuid: str | None,
 ) -> ComputeContext:
     """Fetch or create a compute API session, then poll until ready."""
     if permanent_session_uuid is None:
@@ -37,8 +37,7 @@ async def fetch_session_endpoint(
 
 
 async def fetch_new_compute_session(
-    compute_ctx: ComputeContext,
-    client_session: aiohttp.ClientSession
+    compute_ctx: ComputeContext, client_session: aiohttp.ClientSession
 ) -> ComputeContext:
     headers = {
         "Authorization": f"Bearer {compute_ctx.api_key}",
@@ -48,53 +47,44 @@ async def fetch_new_compute_session(
     sessions_url = f"{compute_ctx.compute_url}/v1/sessions"
 
     res = None
-    need_new_session = False
+    need_new_session = compute_ctx.pop is not None
 
-    try:
-        async with client_session.get(sessions_url, headers=headers) as get_response:
-            log.debug(f"GET /v1/sessions - status: {get_response.status}")
-            if get_response.status == 404:
-                need_new_session = True
-            else:
-                get_response.raise_for_status()
-                res = await get_response.json()
-
-                if not res:
+    if not need_new_session:
+        try:
+            async with client_session.get(sessions_url, headers=headers) as get_response:
+                log.debug(f"GET /v1/sessions - status: {get_response.status}")
+                if get_response.status == 404:
                     need_new_session = True
-                elif isinstance(res, list):
-                    res = [s for s in res if isinstance(s, dict) and not s.get("persistent")]
+                else:
+                    get_response.raise_for_status()
+                    res = await get_response.json()
+
                     if not res:
                         need_new_session = True
-                elif isinstance(res, dict):
-                    if not res.get("session_uuid") or res.get("persistent"):
-                        need_new_session = True
+                    elif isinstance(res, list):
+                        res = [s for s in res if isinstance(s, dict) and not s.get("persistent")]
+                        if not res:
+                            need_new_session = True
+                    elif isinstance(res, dict):
+                        if not res.get("session_uuid") or res.get("persistent"):
+                            need_new_session = True
 
-    except aiohttp.ClientResponseError as e:
-        if e.status == 404:
-            need_new_session = True
-        else:
-            raise ComputeSessionException(
-                f"Failed to fetch existing sessions: {e.message}",
-            ) from e
-    except Exception as e:
-        raise ComputeSessionException(f"Unexpected error fetching sessions: {str(e)}") from e
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                need_new_session = True
+            else:
+                raise ComputeSessionException(
+                    f"Failed to fetch existing sessions: {e.message}",
+                ) from e
+        except Exception as e:
+            raise ComputeSessionException(f"Unexpected error fetching sessions: {str(e)}") from e
 
     if need_new_session:
         try:
-            body = {}
-            if compute_ctx.session_name:
-                body["session_name"] = compute_ctx.session_name
-            if compute_ctx.pipeline_image:
-                body["pipeline_image"] = compute_ctx.pipeline_image
-            if compute_ctx.pipeline_version:
-                body["pipeline_version"] = compute_ctx.pipeline_version
-            if compute_ctx.pop is not None:
-                body["pop"] = compute_ctx.pop
-
             async with client_session.post(
-                f'{sessions_url}?wait=true',
+                f"{sessions_url}?wait=true",
                 headers=headers,
-                json=body if body else None,
+                json=_session_create_body(compute_ctx),
             ) as post_response:
                 post_response.raise_for_status()
                 res = await post_response.json()
@@ -119,6 +109,19 @@ async def fetch_new_compute_session(
     _compute_context_from_response(compute_ctx, res)
 
     return compute_ctx
+
+
+def _session_create_body(compute_ctx: ComputeContext) -> dict[str, Any] | None:
+    body = {}
+    if compute_ctx.session_name:
+        body["session_name"] = compute_ctx.session_name
+    if compute_ctx.pipeline_image:
+        body["pipeline_image"] = compute_ctx.pipeline_image
+    if compute_ctx.pipeline_version:
+        body["pipeline_version"] = compute_ctx.pipeline_version
+    if compute_ctx.pop is not None:
+        body["pop"] = compute_ctx.pop
+    return body if body else None
 
 
 def _compute_context_from_response(compute_ctx: ComputeContext, res: dict | None | Any):
@@ -198,9 +201,7 @@ async def refresh_compute_token(
 
 
 async def fetch_permanent_compute_session(
-    compute_ctx: ComputeContext,
-    client_session: aiohttp.ClientSession,
-    permanent_session_uuid: str
+    compute_ctx: ComputeContext, client_session: aiohttp.ClientSession, permanent_session_uuid: str
 ) -> ComputeContext:
     headers = {
         "Authorization": f"Bearer {compute_ctx.api_key}",

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -70,14 +70,11 @@ async def fetch_new_compute_session(
                             need_new_session = True
 
         except aiohttp.ClientResponseError as e:
-            if e.status == 404:
-                need_new_session = True
-            else:
-                raise ComputeSessionException(
-                    f"Failed to fetch existing sessions: {e.message}",
-                ) from e
+            raise ComputeSessionException(
+                f"Failed to fetch existing sessions: {e.message}",
+            ) from e
         except Exception as e:
-            raise ComputeSessionException(f"Unexpected error fetching sessions: {str(e)}") from e
+            raise ComputeSessionException(f"Unexpected error fetching sessions: {e!s}") from e
 
     if need_new_session:
         try:
@@ -95,7 +92,7 @@ async def fetch_new_compute_session(
             ) from e
         except Exception as e:
             raise ComputeSessionException(
-                f"No existing session and failed to create new one: {str(e)}"
+                f"No existing session and failed to create new one: {e!s}"
             ) from e
 
     if isinstance(res, list):

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -29,9 +29,10 @@ from eyepop.worker.worker_jobs import (
 )
 from eyepop.worker.worker_types import ComponentParams, MotionDetectConfig, Pop, VideoMode
 
-log = logging.getLogger('eyepop')
-log_requests = logging.getLogger('eyepop.requests')
-log_metrics = logging.getLogger('eyepop.metrics')
+log = logging.getLogger("eyepop")
+log_requests = logging.getLogger("eyepop.requests")
+log_metrics = logging.getLogger("eyepop.metrics")
+
 
 def should_use_compute_api(pop_id: str, api_key: str | None) -> bool:
     """Determine if we should use Compute API based on pop_id and api_key."""
@@ -47,26 +48,27 @@ def should_use_compute_api(pop_id: str, api_key: str | None) -> bool:
     log.debug("Using compute API")
     return True
 
+
 class WorkerEndpoint(Endpoint, WorkerClientSession):
     """Endpoint to an EyePop.ai worker."""
 
     def __init__(
-            self,
-            secret_key: str | None,
-            access_token: str | None,
-            api_key: str | None,
-            eyepop_url: str,
-            pop_id: str,
-            session_uuid: str | None,
-            auto_start: bool,
-            stop_jobs: bool,
-            job_queue_length: int,
-            request_tracer_max_buffer: int,
-            dataset_uuid: str | None = None,
-            pipeline_image: str | None = None,
-            pipeline_version: str | None = None,
-            session_name: str | None = None,
-            pop: Pop | dict[str, Any] | None = None,
+        self,
+        secret_key: str | None,
+        access_token: str | None,
+        api_key: str | None,
+        eyepop_url: str,
+        pop_id: str,
+        session_uuid: str | None,
+        auto_start: bool,
+        stop_jobs: bool,
+        job_queue_length: int,
+        request_tracer_max_buffer: int,
+        dataset_uuid: str | None = None,
+        pipeline_image: str | None = None,
+        pipeline_version: str | None = None,
+        session_name: str | None = None,
+        pop: Pop | dict[str, Any] | None = None,
     ):
         super().__init__(
             secret_key=secret_key,
@@ -107,7 +109,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if failed_attempts > 1:
             return False
         else:
-            log_requests.debug('after 404, about to retry with fresh config')
+            log_requests.debug("after 404, about to retry with fresh config")
             self.worker_config = None
             return True
 
@@ -115,19 +117,24 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         client_timeout = None
         if timeout is not None:
             client_timeout = aiohttp.ClientTimeout(total=timeout)
-        if (self.is_dev_mode and self.pop_id == 'transient'
-                and self._has_pipeline_id()
-                and self.client_session is not None):
+        if (
+            self.is_dev_mode
+            and self.pop_id == "transient"
+            and self._has_pipeline_id()
+            and self.client_session is not None
+        ):
             worker_config = self.worker_config
             assert worker_config is not None
             try:
                 base_url = await self.dev_mode_base_url()
-                delete_pipeline_url = f'{base_url}/pipelines/{worker_config["pipeline_id"]}'
+                delete_pipeline_url = f"{base_url}/pipelines/{worker_config['pipeline_id']}"
                 headers = {}
                 authorization_header = await self._authorization_header()
                 if authorization_header is not None:
-                    headers['Authorization'] = authorization_header
-                await self.client_session.delete(delete_pipeline_url, headers=headers, timeout=client_timeout)
+                    headers["Authorization"] = authorization_header
+                await self.client_session.delete(
+                    delete_pipeline_url, headers=headers, timeout=client_timeout
+                )
             except Exception as e:
                 log.exception(e, exc_info=True)
             finally:
@@ -139,12 +146,19 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if self.worker_config is not None:
             return
 
-        if self.last_fetch_config_error_time is not None and self.last_fetch_config_error_time > time.time() - settings.min_config_reconnect_secs:
+        if (
+            self.last_fetch_config_error_time is not None
+            and self.last_fetch_config_error_time > time.time() - settings.min_config_reconnect_secs
+        ):
             if self.last_fetch_config_error is not None:
                 raise self.last_fetch_config_error
             raise aiohttp.ClientConnectionError()
 
-        if self.last_fetch_config_success_time is not None and self.last_fetch_config_success_time > time.time() - settings.min_config_reconnect_secs:
+        if (
+            self.last_fetch_config_success_time is not None
+            and self.last_fetch_config_success_time
+            > time.time() - settings.min_config_reconnect_secs
+        ):
             raise aiohttp.ClientConnectionError()
 
         if self.compute_ctx:
@@ -168,14 +182,16 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             self.last_fetch_config_error = None
             self.last_fetch_config_error_time = None
         else:
-            if self.pop_id == 'transient':
-                config_url = f'{self.eyepop_url}/workers/config'
+            if self.pop_id == "transient":
+                config_url = f"{self.eyepop_url}/workers/config"
             else:
-                config_url = f'{self.eyepop_url}/pops/{self.pop_id}/config?auto_start={self.auto_start}'
+                config_url = (
+                    f"{self.eyepop_url}/pops/{self.pop_id}/config?auto_start={self.auto_start}"
+                )
             headers = {}
             authorization_header = await self._authorization_header()
             if authorization_header is not None:
-                headers['Authorization'] = authorization_header
+                headers["Authorization"] = authorization_header
             try:
                 async with self.client_session.get(config_url, headers=headers) as response:
                     self.worker_config = await response.json()
@@ -193,8 +209,10 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                     headers = {}
                     authorization_header = await self._authorization_header()
                     if authorization_header is not None:
-                        headers['Authorization'] = authorization_header
-                    async with self.client_session.get(config_url, headers=headers) as retried_response:
+                        headers["Authorization"] = authorization_header
+                    async with self.client_session.get(
+                        config_url, headers=headers
+                    ) as retried_response:
                         self.worker_config = await retried_response.json()
             except aiohttp.ClientConnectionError as e:
                 self.last_fetch_config_error = e
@@ -202,19 +220,23 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 raise e
 
         if self.compute_ctx:
-            log_requests.debug(f'Compute session: {self.compute_ctx.session_uuid}')
+            log_requests.debug(f"Compute session: {self.compute_ctx.session_uuid}")
 
-        if self.worker_config.get('status') == 'active_prod':
+        if self.worker_config.get("status") == "active_prod":
             self.is_dev_mode = False
 
         if self.is_dev_mode and self.stop_jobs and self._has_pipeline_id():
-            stop_jobs_url = f'{await self.dev_mode_pipeline_base_url()}/source?mode=preempt&processing=sync'
-            body = {'sourceType': 'NONE'}
+            stop_jobs_url = (
+                f"{await self.dev_mode_pipeline_base_url()}/source?mode=preempt&processing=sync"
+            )
+            body = {"sourceType": "NONE"}
             headers = {}
             authorization_header = await self._authorization_header()
             if authorization_header is not None:
-                headers['Authorization'] = authorization_header
-            async with self.client_session.patch(stop_jobs_url, headers=headers, json=body) as response:
+                headers["Authorization"] = authorization_header
+            async with self.client_session.patch(
+                stop_jobs_url, headers=headers, json=body
+            ) as response:
                 pass
 
         if self.is_dev_mode and self.pop is None and self._has_pipeline_id():
@@ -222,15 +244,15 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             headers = {}
             authorization_header = await self._authorization_header()
             if authorization_header is not None:
-                headers['Authorization'] = authorization_header
+                headers["Authorization"] = authorization_header
             async with self.client_session.get(get_url, headers=headers) as response:
                 response_json = await response.json()
-                pop_as_dict = response_json.get('pop')
+                pop_as_dict = response_json.get("pop")
                 if pop_as_dict is None:
                     self.pop = None
                 else:
                     self.pop = Pop(**pop_as_dict)
-            log.debug('current pop is %s', self.pop)
+            log.debug("current pop is %s", self.pop)
 
         self._configure_load_balancer()
 
@@ -239,13 +261,13 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         session = await super().session()
         if session is None:
             return None
-        session['popId'] = self.pop_id
+        session["popId"] = self.pop_id
         if self.worker_config:
-            if 'session_endpoint' in self.worker_config:
-                session['baseUrl'] = self.worker_config['session_endpoint']
-            elif 'base_url' in self.worker_config:
-                session['baseUrl'] = self.worker_config['base_url']
-            session['pipelineId'] = self.worker_config.get('pipeline_id')
+            if "session_endpoint" in self.worker_config:
+                session["baseUrl"] = self.worker_config["session_endpoint"]
+            elif "base_url" in self.worker_config:
+                session["baseUrl"] = self.worker_config["base_url"]
+            session["pipelineId"] = self.worker_config.get("pipeline_id")
         return session
 
     async def get_pop(self) -> Pop | None:
@@ -253,19 +275,51 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
 
     async def set_pop(self, pop: Pop):
         if not self.is_dev_mode:
-            raise PopConfigurationException(self.pop_id, 'set_pop not supported in production mode')
+            raise PopConfigurationException(self.pop_id, "set_pop not supported in production mode")
         self.pop = pop
         if self.compute_ctx:
             self.compute_ctx.pop = pop.model_dump()
         if self.client_session is None:
             return {"pop": pop.model_dump()}
+        if self.compute_ctx and self.permanent_session_uuid is None:
+            return await self._set_pop_on_compute_transient(pop)
         if self.worker_config is None:
             await self._reconnect()
         if self.is_dev_mode and not self._has_pipeline_id():
             return await self._ensure_pipeline_started()
-        response = await self.pipeline_patch('pop', content_type='application/json',
-                                             data=pop.model_dump_json())
+        response = await self.pipeline_patch(
+            "pop", content_type="application/json", data=pop.model_dump_json()
+        )
         return response
+
+    async def _set_pop_on_compute_transient(self, pop: Pop) -> dict[str, Any]:
+        assert self.compute_ctx is not None
+        assert self.client_session is not None
+
+        if self.worker_config is None:
+            await self._reconnect()
+        if self._has_pipeline_id():
+            await self._disconnect()
+
+        self.compute_ctx.pop = pop.model_dump()
+        self.compute_ctx.pipeline_uuid = ""
+        self.compute_ctx.pipeline_id = ""
+        self.compute_ctx = await fetch_session_endpoint(
+            compute_ctx=self.compute_ctx,
+            client_session=self.client_session,
+            permanent_session_uuid=None,
+        )
+        self.eyepop_url = self.compute_ctx.session_endpoint
+        self.worker_config = {
+            "session_endpoint": self.compute_ctx.session_endpoint,
+            "pipeline_id": self.compute_ctx.pipeline_id,
+            "endpoints": [],
+        }
+        self.last_fetch_config_success_time = time.time()
+        self.last_fetch_config_error = None
+        self.last_fetch_config_error_time = None
+        self._configure_load_balancer()
+        return await self._create_pipeline(wait_until_ready=True)
 
     async def dev_mode_pipeline_base_url(self) -> str:
         # Was `else: pass` which made return type str | None — raise explicitly instead
@@ -276,18 +330,18 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             raise PopNotStartedException(pop_id=self.pop_id)
         if not self._has_pipeline_id():
             await self._ensure_pipeline_started()
-        return f'{base_url}/pipelines/{self.worker_config["pipeline_id"]}'
+        return f"{base_url}/pipelines/{self.worker_config['pipeline_id']}"
 
     async def upload(
-            self,
-            location: str,
-            video_mode: VideoMode | None = None,
-            params: list[ComponentParams] | None = None,
-            motion_detect: MotionDetectConfig | None = None,
-            roi: Area | None = None,
-            fps: str | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        location: str,
+        video_mode: VideoMode | None = None,
+        params: list[ComponentParams] | None = None,
+        motion_detect: MotionDetectConfig | None = None,
+        roi: Area | None = None,
+        fps: str | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         job = _UploadFileJob(
             location=location,
@@ -297,25 +351,26 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             roi=roi,
             fps=fps,
             media_cache_seconds=media_cache_seconds,
-            session=self, on_ready=on_ready,
-            callback=self.metrics_collector
+            session=self,
+            on_ready=on_ready,
+            callback=self.metrics_collector,
         )
-        await  self._task_start(job.execute())
+        await self._task_start(job.execute())
         return job
 
     async def upload_stream(
-            self,
-            stream: BinaryIO | AsyncIterable[bytes],
-            mime_type: str,
-            video_mode: VideoMode | None = None,
-            is_live: bool | None = None,
-            captured_at_offset_ns: int | None = None,
-            params: list[ComponentParams] | None = None,
-            motion_detect: MotionDetectConfig | None = None,
-            roi: Area | None = None,
-            fps: str | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        stream: BinaryIO | AsyncIterable[bytes],
+        mime_type: str,
+        video_mode: VideoMode | None = None,
+        is_live: bool | None = None,
+        captured_at_offset_ns: int | None = None,
+        params: list[ComponentParams] | None = None,
+        motion_detect: MotionDetectConfig | None = None,
+        roi: Area | None = None,
+        fps: str | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         job = _UploadStreamJob(
             stream=stream,
@@ -330,19 +385,19 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
-            callback=self.metrics_collector
+            callback=self.metrics_collector,
         )
         await self._task_start(job.execute())
         return job
 
     async def upload_stream_group(
-            self,
-            streams: list[BinaryIO],
-            mime_types: list[str] | None = None,
-            params: list[ComponentParams] | None = None,
-            roi: Area | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        streams: list[BinaryIO],
+        mime_types: list[str] | None = None,
+        params: list[ComponentParams] | None = None,
+        roi: Area | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         """Uploads multiple in-memory streams as a single image group (one inference unit).
 
@@ -360,18 +415,18 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
-            callback=self.metrics_collector
+            callback=self.metrics_collector,
         )
         await self._task_start(job.execute())
         return job
 
     async def upload_group(
-            self,
-            locations: list[str],
-            params: list[ComponentParams] | None = None,
-            roi: Area | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        locations: list[str],
+        params: list[ComponentParams] | None = None,
+        roi: Area | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         """Uploads multiple local images as a single image group (one inference unit).
 
@@ -385,21 +440,22 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             component_params=params,
             roi=roi,
             media_cache_seconds=media_cache_seconds,
-            session=self, on_ready=on_ready,
-            callback=self.metrics_collector
+            session=self,
+            on_ready=on_ready,
+            callback=self.metrics_collector,
         )
         await self._task_start(job.execute())
         return job
 
     async def load_from(
-            self,
-            location: str,
-            params: list[ComponentParams] | None = None,
-            motion_detect: MotionDetectConfig | None = None,
-            roi: Area | None = None,
-            fps: str | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        location: str,
+        params: list[ComponentParams] | None = None,
+        motion_detect: MotionDetectConfig | None = None,
+        roi: Area | None = None,
+        fps: str | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         job = _LoadFromJob(
             locations=[location],
@@ -410,18 +466,18 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
-            callback=self.metrics_collector
+            callback=self.metrics_collector,
         )
         await self._task_start(job.execute())
         return job
 
     async def load_from_group(
-            self,
-            locations: list[str],
-            params: list[ComponentParams] | None = None,
-            roi: Area | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        locations: list[str],
+        params: list[ComponentParams] | None = None,
+        roi: Area | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         """Loads multiple server-fetched URLs as a single image group (one inference unit).
 
@@ -439,20 +495,20 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
-            callback=self.metrics_collector
+            callback=self.metrics_collector,
         )
         await self._task_start(job.execute())
         return job
 
     async def load_asset(
-            self,
-            asset_uuid: str,
-            params: list[ComponentParams] | None = None,
-            motion_detect: MotionDetectConfig | None = None,
-            roi: Area | None = None,
-            fps: str | None = None,
-            media_cache_seconds: int | None = None,
-            on_ready: Callable[[WorkerJob], None] | None = None
+        self,
+        asset_uuid: str,
+        params: list[ComponentParams] | None = None,
+        motion_detect: MotionDetectConfig | None = None,
+        roi: Area | None = None,
+        fps: str | None = None,
+        media_cache_seconds: int | None = None,
+        on_ready: Callable[[WorkerJob], None] | None = None,
     ) -> WorkerJob:
         job = _LoadFromAssetUuidJob(
             asset_uuid=asset_uuid,
@@ -463,7 +519,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             media_cache_seconds=media_cache_seconds,
             session=self,
             on_ready=on_ready,
-            callback=self.metrics_collector
+            callback=self.metrics_collector,
         )
         await self._task_start(job.execute())
         return job
@@ -473,19 +529,17 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             await self._reconnect()
         if self.worker_config is None:
             raise PopNotStartedException(pop_id=self.pop_id)
-        if 'session_endpoint' in self.worker_config:
-            return self.worker_config['session_endpoint'].rstrip("/")
-        return urljoin(self.eyepop_url, self.worker_config['base_url']).rstrip("/")
+        if "session_endpoint" in self.worker_config:
+            return self.worker_config["session_endpoint"].rstrip("/")
+        return urljoin(self.eyepop_url, self.worker_config["base_url"]).rstrip("/")
 
     def _has_pipeline_id(self) -> bool:
-        return self.worker_config is not None and bool(self.worker_config.get('pipeline_id'))
+        return self.worker_config is not None and bool(self.worker_config.get("pipeline_id"))
 
     def _pipeline_create_body(self) -> dict[str, Any]:
         body = {
             "pop": self.pop.model_dump() if self.pop else {},
-            "source": {
-                "sourceType": "NONE"
-            },
+            "source": {"sourceType": "NONE"},
             "idleTimeoutSeconds": 300,
             "logging": ["out_meta"],
             "videoOutput": "no_output",
@@ -502,35 +556,64 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 return None
             return await self._create_pipeline()
 
-    async def _create_pipeline(self) -> dict[str, Any]:
+    async def _create_pipeline(self, wait_until_ready: bool = False) -> dict[str, Any]:
         assert self.client_session is not None
         if self.worker_config is None:
             await self._reconnect()
         if self.worker_config is None:
             raise PopNotStartedException(pop_id=self.pop_id)
 
-        start_pipeline_url = f'{await self.dev_mode_base_url()}/pipelines'
+        start_pipeline_url = f"{await self.dev_mode_base_url()}/pipelines"
         headers = {}
         authorization_header = await self._authorization_header()
         if authorization_header is not None:
-            headers['Authorization'] = authorization_header
+            headers["Authorization"] = authorization_header
 
         async with self.client_session.post(
-                start_pipeline_url,
-                headers=headers,
-                json=self._pipeline_create_body(),
+            start_pipeline_url,
+            headers=headers,
+            json=self._pipeline_create_body(),
         ) as response:
             response.raise_for_status()
             response_json = await response.json()
 
-        self.worker_config['pipeline_id'] = response_json['id']
+        self.worker_config["pipeline_id"] = response_json["id"]
         if self.compute_ctx:
-            self.compute_ctx.pipeline_uuid = response_json['id']
-            self.compute_ctx.pipeline_id = response_json['id']
+            self.compute_ctx.pipeline_uuid = response_json["id"]
+            self.compute_ctx.pipeline_id = response_json["id"]
             log.debug(f"Created pipeline with ID: {response_json['id']}")
 
         self._configure_load_balancer()
+        if wait_until_ready:
+            await self._wait_for_pipeline_ready()
         return response_json
+
+    async def _wait_for_pipeline_ready(self):
+        assert self.client_session is not None
+        timeout = settings.session_timeout
+        interval = settings.session_interval
+        end_time = asyncio.get_event_loop().time() + timeout
+        last_message = "No message received"
+        request_timeout = aiohttp.ClientTimeout(total=interval)
+
+        while asyncio.get_event_loop().time() < end_time:
+            try:
+                get_url = await self.dev_mode_pipeline_base_url()
+                headers = {}
+                authorization_header = await self._authorization_header()
+                if authorization_header is not None:
+                    headers["Authorization"] = authorization_header
+                async with self.client_session.get(
+                    get_url, headers=headers, timeout=request_timeout
+                ) as response:
+                    await response.json()
+                    return
+            except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as e:
+                last_message = str(e)
+                log_requests.debug("waiting for pipeline ready: %s", last_message)
+                await asyncio.sleep(interval)
+
+        raise TimeoutError(f"Pipeline timed out after {timeout}s. Last message: {last_message}")
 
     def _configure_load_balancer(self):
         if self.worker_config is None:
@@ -540,22 +623,24 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             if not self._has_pipeline_id():
                 self.load_balancer = EndpointLoadBalancer([])
                 return
-            if 'session_endpoint' in self.worker_config:
-                base_url = self.worker_config['session_endpoint'].rstrip("/")
+            if "session_endpoint" in self.worker_config:
+                base_url = self.worker_config["session_endpoint"].rstrip("/")
             else:
-                base_url = urljoin(self.eyepop_url, self.worker_config['base_url']).rstrip("/")
-            endpoint = {'base_url': base_url, 'pipeline_id': self.worker_config['pipeline_id']}
+                base_url = urljoin(self.eyepop_url, self.worker_config["base_url"]).rstrip("/")
+            endpoint = {"base_url": base_url, "pipeline_id": self.worker_config["pipeline_id"]}
             self.load_balancer = EndpointLoadBalancer([endpoint])
             log.debug(f"Initialized load balancer with endpoint: {endpoint}")
         else:
-            if 'session_endpoint' in self.worker_config:
-                base_url = self.worker_config['session_endpoint'].rstrip("/")
-                endpoint = {'base_url': base_url, 'pipeline_id': self.worker_config['pipeline_id']}
+            if "session_endpoint" in self.worker_config:
+                base_url = self.worker_config["session_endpoint"].rstrip("/")
+                endpoint = {"base_url": base_url, "pipeline_id": self.worker_config["pipeline_id"]}
                 self.load_balancer = EndpointLoadBalancer([endpoint])
                 log.debug(f"Initialized load balancer with endpoint: {endpoint}")
             else:
-                self.load_balancer = EndpointLoadBalancer(self.worker_config['endpoints'])
-                log.debug(f"Initialized load balancer with endpoints: {self.worker_config['endpoints']}")
+                self.load_balancer = EndpointLoadBalancer(self.worker_config["endpoints"])
+                log.debug(
+                    f"Initialized load balancer with endpoints: {self.worker_config['endpoints']}"
+                )
 
     #
     # Implements: _WorkerClientSession
@@ -563,38 +648,79 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
     # await the request and return the response directly, not a context manager.
     #
 
-    async def pipeline_get(self, url_path_and_query: str, accept: str | None = None,
-                           timeout: aiohttp.ClientTimeout | None = None) -> aiohttp.ClientResponse:
-        return await self._pipeline_request_with_retry('GET', url_path_and_query, accept=accept, timeout=timeout)
+    async def pipeline_get(
+        self,
+        url_path_and_query: str,
+        accept: str | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> aiohttp.ClientResponse:
+        return await self._pipeline_request_with_retry(
+            "GET", url_path_and_query, accept=accept, timeout=timeout
+        )
 
-    async def pipeline_post(self, url_path_and_query: str, accept: str | None = None, open_data: Callable | None = None,
-                            content_type: str | None = None,
-                            timeout: aiohttp.ClientTimeout | None = None) -> aiohttp.ClientResponse:
-        return await self._pipeline_request_with_retry('POST', url_path_and_query, accept=accept, open_data=open_data,
-                                                       content_type=content_type, timeout=timeout)
+    async def pipeline_post(
+        self,
+        url_path_and_query: str,
+        accept: str | None = None,
+        open_data: Callable | None = None,
+        content_type: str | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> aiohttp.ClientResponse:
+        return await self._pipeline_request_with_retry(
+            "POST",
+            url_path_and_query,
+            accept=accept,
+            open_data=open_data,
+            content_type=content_type,
+            timeout=timeout,
+        )
 
-    async def pipeline_patch(self, url_path_and_query: str, accept: str | None = None, data: Any = None,
-                             content_type: str | None = None,
-                             timeout: aiohttp.ClientTimeout | None = None) -> aiohttp.ClientResponse:
+    async def pipeline_patch(
+        self,
+        url_path_and_query: str,
+        accept: str | None = None,
+        data: Any = None,
+        content_type: str | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> aiohttp.ClientResponse:
         def open_data():
             if isinstance(data, str):
                 return StringIO(data)
             else:
                 return data
 
-        return await self._pipeline_request_with_retry('PATCH', url_path_and_query, accept=accept, open_data=open_data,
-                                                       content_type=content_type, timeout=timeout)
+        return await self._pipeline_request_with_retry(
+            "PATCH",
+            url_path_and_query,
+            accept=accept,
+            open_data=open_data,
+            content_type=content_type,
+            timeout=timeout,
+        )
 
-    async def pipeline_delete(self, url_path_and_query: str,
-                              timeout: aiohttp.ClientTimeout | None = None) -> aiohttp.ClientResponse:
-        return await self._pipeline_request_with_retry('DELETE', url_path_and_query, timeout=timeout)
+    async def pipeline_delete(
+        self, url_path_and_query: str, timeout: aiohttp.ClientTimeout | None = None
+    ) -> aiohttp.ClientResponse:
+        return await self._pipeline_request_with_retry(
+            "DELETE", url_path_and_query, timeout=timeout
+        )
 
-    async def _pipeline_request_with_retry(self, method: str, url_path_and_query: str, accept: str | None = None,
-                                           open_data: Callable | None = None, content_type: str | None = None,
-                                           timeout: aiohttp.ClientTimeout | None = None) -> aiohttp.ClientResponse:
+    async def _pipeline_request_with_retry(
+        self,
+        method: str,
+        url_path_and_query: str,
+        accept: str | None = None,
+        open_data: Callable | None = None,
+        content_type: str | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> aiohttp.ClientResponse:
         # Narrow Optional[ClientSession] for all .request() calls below
         assert self.client_session is not None
-        if self.last_fetch_config_success_time is not None and self.last_fetch_config_success_time < time.time() - settings.force_refresh_config_secs:
+        if (
+            self.last_fetch_config_success_time is not None
+            and self.last_fetch_config_success_time
+            < time.time() - settings.force_refresh_config_secs
+        ):
             self.worker_config = None
 
         failed_attempts = 0
@@ -612,40 +738,49 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             if entry is None:
                 if not retried_re_config:
                     # pipeline might have just shut down
-                    log_requests.debug('no healthy endpoints, about to retry with fresh config')
+                    log_requests.debug("no healthy endpoints, about to retry with fresh config")
                     self.worker_config = None
                     retried_re_config = True
                     continue
                 else:
-                    raise PopNotReachableException(self.pop_id, self.load_balancer.get_debug_status())
+                    raise PopNotReachableException(
+                        self.pop_id, self.load_balancer.get_debug_status()
+                    )
 
-            url = f'{entry.base_url}/pipelines/{entry.pipeline_id}/{url_path_and_query}'
+            url = f"{entry.base_url}/pipelines/{entry.pipeline_id}/{url_path_and_query}"
 
             headers = {}
             authorization_header = await self._authorization_header()
             if authorization_header is not None:
-                headers['Authorization'] = authorization_header
+                headers["Authorization"] = authorization_header
             if accept is not None:
-                headers['Accept'] = accept
+                headers["Accept"] = accept
             if content_type is not None:
-                headers['Content-Type'] = content_type
+                headers["Content-Type"] = content_type
             try:
                 if open_data is not None:
                     data = open_data()
                     if isinstance(data, StringIO):
-                        response = await self.client_session.request(method, url, headers=headers,
-                                                                     data=data.getvalue(), timeout=timeout)
+                        response = await self.client_session.request(
+                            method, url, headers=headers, data=data.getvalue(), timeout=timeout
+                        )
                     elif isinstance(data, AsyncIterable):
+
                         async def data_streamer(_data: AsyncIterable):
                             async for chunk in _data:
                                 yield chunk
-                        response = await self.client_session.request(method, url, headers=headers, data=data_streamer(data),
-                                                                     timeout=timeout)
+
+                        response = await self.client_session.request(
+                            method, url, headers=headers, data=data_streamer(data), timeout=timeout
+                        )
                     else:
-                        response = await self.client_session.request(method, url, headers=headers, data=data,
-                                                                     timeout=timeout)
+                        response = await self.client_session.request(
+                            method, url, headers=headers, data=data, timeout=timeout
+                        )
                 else:
-                    response = await self.client_session.request(method, url, headers=headers, timeout=timeout)
+                    response = await self.client_session.request(
+                        method, url, headers=headers, timeout=timeout
+                    )
 
                 entry.mark_success()
 
@@ -657,21 +792,27 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 else:
                     failed_attempts += 1
                     if e.status not in self.retry_handlers:
-                        log_requests.exception('unexpected error: %s', e)
+                        log_requests.exception("unexpected error: %s", e)
                         raise e
                     if not await self.retry_handlers[e.status](e.status, failed_attempts):
-                        log_requests.exception('unexpected error')
+                        log_requests.exception("unexpected error")
                         raise e
             except aiohttp.ClientConnectionError:
                 entry.mark_error()
             except Exception as e:
-                log_requests.exception('unexpected error')
+                log_requests.exception("unexpected error")
                 raise e
 
         raise PopNotReachableException(self.pop_id, [])
 
-    async def _worker_request_with_retry(self, method: str, url_path_and_query: str, accept: str | None = None,
-                                         data: Any = None, content_type: str | None = None,
-                                         timeout: aiohttp.ClientTimeout | None = None) -> aiohttp.ClientResponse:
-        url = f'{await self.dev_mode_base_url()}/{url_path_and_query}'
+    async def _worker_request_with_retry(
+        self,
+        method: str,
+        url_path_and_query: str,
+        accept: str | None = None,
+        data: Any = None,
+        content_type: str | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> aiohttp.ClientResponse:
+        url = f"{await self.dev_mode_base_url()}/{url_path_and_query}"
         return await self.request_with_retry(method, url, accept, data, content_type, timeout)

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -105,15 +105,21 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
 
         self.add_retry_handler(404, self._retry_404)
 
+    def _reset_config_fetch_state(self) -> None:
+        self.last_fetch_config_success_time = None
+        self.last_fetch_config_error = None
+        self.last_fetch_config_error_time = None
+
     async def _retry_404(self, status_code: int, failed_attempts: int) -> bool:
         if failed_attempts > 1:
             return False
         else:
             log_requests.debug("after 404, about to retry with fresh config")
             self.worker_config = None
+            self._reset_config_fetch_state()
             return True
 
-    async def _disconnect(self, timeout: float | None = None):
+    async def _disconnect(self, timeout: float | None = None, *, suppress_errors: bool = True):
         client_timeout = None
         if timeout is not None:
             client_timeout = aiohttp.ClientTimeout(total=timeout)
@@ -125,6 +131,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         ):
             worker_config = self.worker_config
             assert worker_config is not None
+            deleted_pipeline = False
             try:
                 base_url = await self.dev_mode_base_url()
                 delete_pipeline_url = f"{base_url}/pipelines/{worker_config['pipeline_id']}"
@@ -132,13 +139,21 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 authorization_header = await self._authorization_header()
                 if authorization_header is not None:
                     headers["Authorization"] = authorization_header
-                await self.client_session.delete(
+                response = await self.client_session.delete(
                     delete_pipeline_url, headers=headers, timeout=client_timeout
                 )
+                try:
+                    response.raise_for_status()
+                    deleted_pipeline = True
+                finally:
+                    response.release()
             except Exception as e:
                 log.exception(e, exc_info=True)
+                if not suppress_errors:
+                    raise
             finally:
-                del worker_config["pipeline_id"]
+                if suppress_errors or deleted_pipeline:
+                    worker_config.pop("pipeline_id", None)
 
     async def _reconnect(self):
         # Narrow Optional[ClientSession] — _reconnect is only called after connect()
@@ -290,7 +305,11 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         response = await self.pipeline_patch(
             "pop", content_type="application/json", data=pop.model_dump_json()
         )
-        return response
+        try:
+            response.raise_for_status()
+            return await response.json()
+        finally:
+            response.release()
 
     async def _set_pop_on_compute_transient(self, pop: Pop) -> dict[str, Any]:
         assert self.compute_ctx is not None
@@ -299,7 +318,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if self.worker_config is None:
             await self._reconnect()
         if self._has_pipeline_id():
-            await self._disconnect()
+            await self._disconnect(suppress_errors=False)
 
         self.compute_ctx.pop = pop.model_dump()
         self.compute_ctx.pipeline_uuid = ""
@@ -740,6 +759,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                     # pipeline might have just shut down
                     log_requests.debug("no healthy endpoints, about to retry with fresh config")
                     self.worker_config = None
+                    self._reset_config_fetch_state()
                     retried_re_config = True
                     continue
                 else:

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -19,21 +19,15 @@ MOCK_SESSION_RESPONSE = {
     "session_status": "running",
     "session_message": "Session created successfully",
     "pipeline_ttl": 3600,
-    "session_active": True
+    "session_active": True,
 }
 
-MOCK_SESSION_RESPONSE_NO_PIPELINES = {
-    **MOCK_SESSION_RESPONSE,
-    "pipelines": []
-}
+MOCK_SESSION_RESPONSE_NO_PIPELINES = {**MOCK_SESSION_RESPONSE, "pipelines": []}
 
 
 @pytest.fixture
 def mock_compute_config():
-    return ComputeContext(
-        compute_url="https://compute.staging.eyepop.xyz",
-        api_key="test-api-key"
-    )
+    return ComputeContext(compute_url="https://compute.staging.eyepop.xyz", api_key="test-api-key")
 
 
 @pytest.mark.asyncio
@@ -41,7 +35,7 @@ async def test_fetches_existing_session_successfully(mock_compute_config, aiores
     aioresponses.get(
         "https://compute.staging.eyepop.xyz/v1/sessions",
         payload=[MOCK_SESSION_RESPONSE],
-        status=200
+        status=200,
     )
 
     async with aiohttp.ClientSession() as session:
@@ -54,15 +48,11 @@ async def test_fetches_existing_session_successfully(mock_compute_config, aiores
 
 @pytest.mark.asyncio
 async def test_creates_session_when_none_exists(mock_compute_config, aioresponses):
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        payload=[],
-        status=200
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", payload=[], status=200)
     aioresponses.post(
         "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
         payload=MOCK_SESSION_RESPONSE,
-        status=200
+        status=200,
     )
 
     async with aiohttp.ClientSession() as session:
@@ -86,14 +76,9 @@ async def test_creates_session_with_pop_for_scheduling(aioresponses):
         captured_body.update(kwargs["json"])
         return CallbackResult(body=json.dumps(MOCK_SESSION_RESPONSE), status=200)
 
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        payload=[],
-        status=200
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", payload=[], status=200)
     aioresponses.post(
-        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
-        callback=create_session
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true", callback=create_session
     )
 
     async with aiohttp.ClientSession() as session:
@@ -110,14 +95,9 @@ async def test_creates_session_without_pop_when_unset(mock_compute_config, aiore
         captured_body.update(kwargs.get("json") or {})
         return CallbackResult(body=json.dumps(MOCK_SESSION_RESPONSE), status=200)
 
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        payload=[],
-        status=200
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", payload=[], status=200)
     aioresponses.post(
-        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
-        callback=create_session
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true", callback=create_session
     )
 
     async with aiohttp.ClientSession() as session:
@@ -128,14 +108,11 @@ async def test_creates_session_without_pop_when_unset(mock_compute_config, aiore
 
 @pytest.mark.asyncio
 async def test_creates_session_when_get_returns_404(mock_compute_config, aioresponses):
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        status=404
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", status=404)
     aioresponses.post(
         "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
         payload=MOCK_SESSION_RESPONSE,
-        status=200
+        status=200,
     )
 
     async with aiohttp.ClientSession() as session:
@@ -148,9 +125,7 @@ async def test_creates_session_when_get_returns_404(mock_compute_config, aioresp
 @pytest.mark.asyncio
 async def test_handles_single_session_response(mock_compute_config, aioresponses):
     aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        payload=MOCK_SESSION_RESPONSE,
-        status=200
+        "https://compute.staging.eyepop.xyz/v1/sessions", payload=MOCK_SESSION_RESPONSE, status=200
     )
 
     async with aiohttp.ClientSession() as session:
@@ -165,7 +140,7 @@ async def test_handles_empty_pipelines_list(mock_compute_config, aioresponses):
     aioresponses.get(
         "https://compute.staging.eyepop.xyz/v1/sessions",
         payload=[MOCK_SESSION_RESPONSE_NO_PIPELINES],
-        status=200
+        status=200,
     )
 
     async with aiohttp.ClientSession() as session:
@@ -182,7 +157,7 @@ async def test_raises_exception_when_no_access_token(mock_compute_config, aiores
     aioresponses.get(
         "https://compute.staging.eyepop.xyz/v1/sessions",
         payload=[response_without_token],
-        status=200
+        status=200,
     )
 
     async with aiohttp.ClientSession() as session:
@@ -192,10 +167,7 @@ async def test_raises_exception_when_no_access_token(mock_compute_config, aiores
 
 @pytest.mark.asyncio
 async def test_raises_exception_on_http_error(mock_compute_config, aioresponses):
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        status=500
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", status=500)
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(ComputeSessionException):
@@ -204,10 +176,7 @@ async def test_raises_exception_on_http_error(mock_compute_config, aioresponses)
 
 @pytest.mark.asyncio
 async def test_raises_exception_on_403_forbidden(mock_compute_config, aioresponses):
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        status=403
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", status=403)
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(ComputeSessionException):
@@ -216,14 +185,10 @@ async def test_raises_exception_on_403_forbidden(mock_compute_config, aiorespons
 
 @pytest.mark.asyncio
 async def test_raises_exception_when_post_fails(mock_compute_config, aioresponses):
-    aioresponses.get(
-        "https://compute.staging.eyepop.xyz/v1/sessions",
-        payload=[],
-        status=200
-    )
+    aioresponses.get("https://compute.staging.eyepop.xyz/v1/sessions", payload=[], status=200)
     aioresponses.post(
         "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
-        exception=Exception("Failed to create session")
+        exception=Exception("Failed to create session"),
     )
 
     async with aiohttp.ClientSession() as session:
@@ -239,7 +204,7 @@ async def test_fetch_session_endpoint_with_health_check(mock_fetch_new, mock_wai
         compute_url="https://compute.staging.eyepop.xyz",
         api_key="test-key",
         session_endpoint="https://session.example.com",
-        m2m_access_token="jwt-123"
+        m2m_access_token="jwt-123",
     )
     mock_fetch_new.return_value = mock_context
     mock_wait.return_value = True
@@ -270,15 +235,12 @@ async def test_fetch_session_endpoint_raises_on_health_check_failure(mock_fetch_
 @patch("eyepop.compute.api.fetch_new_compute_session")
 async def test_fetch_session_endpoint_passes_context(mock_fetch_new, mock_wait):
     """Test that fetch_session_endpoint correctly passes context through."""
-    input_context = ComputeContext(
-        compute_url="https://custom.compute.com",
-        api_key="custom-key"
-    )
+    input_context = ComputeContext(compute_url="https://custom.compute.com", api_key="custom-key")
     mock_context = ComputeContext(
         compute_url="https://custom.compute.com",
         api_key="custom-key",
         session_endpoint="https://session.example.com",
-        m2m_access_token="jwt-123"
+        m2m_access_token="jwt-123",
     )
     mock_fetch_new.return_value = mock_context
     mock_wait.return_value = True
@@ -432,7 +394,9 @@ async def test_creates_new_session_when_only_persistent_exist(mock_compute_confi
 
 
 @pytest.mark.asyncio
-async def test_creates_new_session_when_single_dict_is_persistent(mock_compute_config, aioresponses):
+async def test_creates_new_session_when_single_dict_is_persistent(
+    mock_compute_config, aioresponses
+):
     """GET returns a single persistent dict → SDK must not adopt it; POST instead."""
     aioresponses.get(
         "https://compute.staging.eyepop.xyz/v1/sessions",

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -14,7 +14,6 @@ from tests.worker.base_endpoint_test import BaseEndpointTest
 
 
 class TestEndpointConnect(BaseEndpointTest):
-
     def test_missing_secret(self):
         with self.assertRaises(KeyError):
             EyePopSdk.sync_worker()
@@ -55,19 +54,30 @@ class TestEndpointConnect(BaseEndpointTest):
 
     @aioresponses()
     def test_connect_ok(self, mock: aioresponses):
-
         self.setup_base_mock(mock)
 
-        mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
-            {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+        mock.post(
+            f"{self.test_eyepop_url}/authentication/token",
+            status=200,
+            body=json.dumps(
+                {
+                    "expires_in": 1000 * 1000,
+                    "token_type": "Bearer",
+                    "access_token": self.test_access_token,
+                }
+            ),
+        )
+
         # automatic call to get pop comp and store
         def get_pop(url, **kwargs) -> CallbackResult:
-            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                return CallbackResult(status=401, reason='test auth token expired')
+            if kwargs["headers"]["Authorization"] != f"Bearer {self.test_access_token}":
+                return CallbackResult(status=401, reason="test auth token expired")
             else:
-                return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()}))
-        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}',
-                    callback=get_pop)
+                return CallbackResult(
+                    status=200, body=json.dumps({"pop": Pop(components=[]).model_dump()})
+                )
+
+        mock.get(f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", callback=get_pop)
         endpoint = EyePopSdk.sync_worker(
             eyepop_url=self.test_eyepop_url,
             secret_key=self.test_eyepop_secret_key,
@@ -82,23 +92,24 @@ class TestEndpointConnect(BaseEndpointTest):
 
     @aioresponses()
     def test_connect_with_token_ok(self, mock: aioresponses):
-
         provided_access_token = uuid.uuid4().hex
 
         self.setup_base_mock(mock, provided_access_token=provided_access_token)
 
         # automatic call to get pop comp and store
         def get_pop(url, **kwargs) -> CallbackResult:
-            if kwargs['headers']['Authorization'] != f'Bearer {provided_access_token}':
-                return CallbackResult(status=401, reason='test auth token expired')
+            if kwargs["headers"]["Authorization"] != f"Bearer {provided_access_token}":
+                return CallbackResult(status=401, reason="test auth token expired")
             else:
-                return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()}))
-        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}',
-                    callback=get_pop)
+                return CallbackResult(
+                    status=200, body=json.dumps({"pop": Pop(components=[]).model_dump()})
+                )
+
+        mock.get(f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", callback=get_pop)
         endpoint = EyePopSdk.sync_worker(
             eyepop_url=self.test_eyepop_url,
             access_token=provided_access_token,
-            pop_id=self.test_eyepop_pop_id
+            pop_id=self.test_eyepop_pop_id,
         )
         try:
             endpoint.connect()
@@ -109,24 +120,34 @@ class TestEndpointConnect(BaseEndpointTest):
 
     @aioresponses()
     def test_connect_transient_ok(self, mock: aioresponses):
-
         self.setup_base_mock(mock, is_transient=True)
 
-        mock.post(f'{self.test_eyepop_url}/authentication/token', status=200, body=json.dumps(
-            {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+        mock.post(
+            f"{self.test_eyepop_url}/authentication/token",
+            status=200,
+            body=json.dumps(
+                {
+                    "expires_in": 1000 * 1000,
+                    "token_type": "Bearer",
+                    "access_token": self.test_access_token,
+                }
+            ),
+        )
+
         # automatic call to get pop comp and store
         def get_pop(url, **kwargs) -> CallbackResult:
-            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                return CallbackResult(status=401, reason='test auth token expired')
+            if kwargs["headers"]["Authorization"] != f"Bearer {self.test_access_token}":
+                return CallbackResult(status=401, reason="test auth token expired")
             else:
-                return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()
-}))
-        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}',
-                    callback=get_pop)
+                return CallbackResult(
+                    status=200, body=json.dumps({"pop": Pop(components=[]).model_dump()})
+                )
+
+        mock.get(f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", callback=get_pop)
         endpoint = EyePopSdk.sync_worker(
             eyepop_url=self.test_eyepop_url,
             secret_key=self.test_eyepop_secret_key,
-            pop_id='transient',
+            pop_id="transient",
         )
         try:
             endpoint.connect()
@@ -136,18 +157,105 @@ class TestEndpointConnect(BaseEndpointTest):
         self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     @aioresponses()
+    async def test_set_pop_on_compute_transient_rechecks_session_scheduling(
+        self, mock: aioresponses
+    ):
+        new_pop = Pop(components=[])
+        captured_session_body = {}
+        captured_pipeline_body = {}
+        session_response = {
+            "session_uuid": "session-456",
+            "session_endpoint": self.test_worker_url,
+            "access_token": self.test_access_token,
+            "pipelines": [{"pipeline_id": self.test_pipeline_id}],
+            "session_status": "running",
+        }
+        session_response_without_pipeline = {
+            **session_response,
+            "pipelines": [],
+        }
+
+        def create_or_update_session(url, **kwargs) -> CallbackResult:
+            captured_session_body.update(kwargs["json"])
+            return CallbackResult(status=200, body=json.dumps(session_response_without_pipeline))
+
+        def create_pipeline(url, **kwargs) -> CallbackResult:
+            captured_pipeline_body.update(kwargs["json"])
+            return CallbackResult(status=200, body=json.dumps({"id": self.test_pipeline_id}))
+
+        mock.get(
+            f"{self.test_eyepop_url}/v1/sessions", status=200, body=json.dumps([session_response])
+        )
+        mock.post(
+            f"{self.test_eyepop_url}/v1/sessions?wait=true", callback=create_or_update_session
+        )
+        mock.get(
+            f"{self.test_worker_url}/health",
+            status=200,
+            body=json.dumps({"message": "ok"}),
+            repeat=True,
+        )
+        mock.delete(
+            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", status=204, repeat=True
+        )
+        mock.post(f"{self.test_worker_url}/pipelines", callback=create_pipeline)
+        mock.get(
+            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}",
+            status=200,
+            body=json.dumps({"pop": new_pop.model_dump(), "status": "IDLE"}),
+            repeat=True,
+        )
+
+        endpoint = EyePopSdk.async_worker(
+            eyepop_url=self.test_eyepop_url,
+            api_key="test-api-key",
+            pop_id="transient",
+            stop_jobs=False,
+        )
+        try:
+            await endpoint.connect()
+            response = await endpoint.set_pop(new_pop)
+
+            self.assertEqual(response["id"], self.test_pipeline_id)
+            self.assertEqual(captured_session_body["pop"], new_pop.model_dump())
+            self.assertEqual(captured_pipeline_body["pop"], new_pop.model_dump())
+        finally:
+            await endpoint.disconnect()
+
+        mock.assert_called_with(
+            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {self.test_access_token}"},
+            timeout=None,
+        )
+        mock.assert_called_with(
+            f"{self.test_eyepop_url}/v1/sessions?wait=true",
+            method="POST",
+            headers={
+                "Authorization": "Bearer test-api-key",
+                "Accept": "application/json",
+            },
+            json={"pop": new_pop.model_dump()},
+        )
+
+    @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):
         self.setup_base_mock(mock)
 
-        mock.post(f'{self.test_eyepop_url}/authentication/token', status=401, body="test unauthorized")
+        mock.post(
+            f"{self.test_eyepop_url}/authentication/token", status=401, body="test unauthorized"
+        )
+
         # automatic call to get pop comp and store
         def get_pop(url, **kwargs) -> CallbackResult:
-            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                return CallbackResult(status=401, reason='test auth token expired')
+            if kwargs["headers"]["Authorization"] != f"Bearer {self.test_access_token}":
+                return CallbackResult(status=401, reason="test auth token expired")
             else:
-                return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()}))
-        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}',
-                    callback=get_pop)
+                return CallbackResult(
+                    status=200, body=json.dumps({"pop": Pop(components=[]).model_dump()})
+                )
+
+        mock.get(f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", callback=get_pop)
         endpoint = EyePopSdk.sync_worker(
             eyepop_url=self.test_eyepop_url,
             secret_key=self.test_eyepop_secret_key,
@@ -162,7 +270,6 @@ class TestEndpointConnect(BaseEndpointTest):
 
     @aioresponses()
     def test_connect_reauth_expired(self, mock: aioresponses):
-
         self.setup_base_mock(mock)
 
         auth_calls = 0
@@ -170,26 +277,44 @@ class TestEndpointConnect(BaseEndpointTest):
         def first_auth(url, **kwargs) -> CallbackResult:
             nonlocal auth_calls
             auth_calls += 1
-            return CallbackResult(status=200, body=json.dumps(
-                {'expires_in': 1, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+            return CallbackResult(
+                status=200,
+                body=json.dumps(
+                    {
+                        "expires_in": 1,
+                        "token_type": "Bearer",
+                        "access_token": self.test_access_token,
+                    }
+                ),
+            )
 
         def second_auth(url, **kwargs) -> CallbackResult:
             nonlocal auth_calls
             auth_calls += 1
-            return CallbackResult(status=200, body=json.dumps(
-                {'expires_in': 1000 * 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+            return CallbackResult(
+                status=200,
+                body=json.dumps(
+                    {
+                        "expires_in": 1000 * 1000,
+                        "token_type": "Bearer",
+                        "access_token": self.test_access_token,
+                    }
+                ),
+            )
 
-        mock.post(f'{self.test_eyepop_url}/authentication/token', callback=first_auth)
-        mock.post(f'{self.test_eyepop_url}/authentication/token', callback=second_auth)
+        mock.post(f"{self.test_eyepop_url}/authentication/token", callback=first_auth)
+        mock.post(f"{self.test_eyepop_url}/authentication/token", callback=second_auth)
+
         # automatic call to get pop comp and store
         def get_pop(url, **kwargs) -> CallbackResult:
-            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                return CallbackResult(status=401, reason='test auth token expired')
+            if kwargs["headers"]["Authorization"] != f"Bearer {self.test_access_token}":
+                return CallbackResult(status=401, reason="test auth token expired")
             else:
-                return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()
-}))
-        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}',
-                    callback=get_pop)
+                return CallbackResult(
+                    status=200, body=json.dumps({"pop": Pop(components=[]).model_dump()})
+                )
+
+        mock.get(f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", callback=get_pop)
         endpoint = EyePopSdk.sync_worker(
             eyepop_url=self.test_eyepop_url,
             secret_key=self.test_eyepop_secret_key,
@@ -213,24 +338,42 @@ class TestEndpointConnect(BaseEndpointTest):
         def auth(url, **kwargs) -> CallbackResult:
             nonlocal auth_calls
             if auth_calls == 0:
-                result = CallbackResult(status=200, body=json.dumps(
-                    {'expires_in': 1000, 'token_type': 'Bearer', 'access_token': self.test_expired_access_token}))
+                result = CallbackResult(
+                    status=200,
+                    body=json.dumps(
+                        {
+                            "expires_in": 1000,
+                            "token_type": "Bearer",
+                            "access_token": self.test_expired_access_token,
+                        }
+                    ),
+                )
             else:
-                result = CallbackResult(status=200, body=json.dumps(
-                    {'expires_in': 1000, 'token_type': 'Bearer', 'access_token': self.test_access_token}))
+                result = CallbackResult(
+                    status=200,
+                    body=json.dumps(
+                        {
+                            "expires_in": 1000,
+                            "token_type": "Bearer",
+                            "access_token": self.test_access_token,
+                        }
+                    ),
+                )
             auth_calls += 1
             return result
 
-        mock.post(f'{self.test_eyepop_url}/authentication/token', callback=auth, repeat=True)
+        mock.post(f"{self.test_eyepop_url}/authentication/token", callback=auth, repeat=True)
+
         # automatic call to get pop comp and store
         def get_pop(url, **kwargs) -> CallbackResult:
-            if kwargs['headers']['Authorization'] != f'Bearer {self.test_access_token}':
-                return CallbackResult(status=401, reason='test auth token expired')
+            if kwargs["headers"]["Authorization"] != f"Bearer {self.test_access_token}":
+                return CallbackResult(status=401, reason="test auth token expired")
             else:
-                return CallbackResult(status=200, body=json.dumps({'pop': Pop(components=[]).model_dump()
-}))
-        mock.get(f'{self.test_worker_url}/pipelines/{self.test_pipeline_id}',
-                    callback=get_pop)
+                return CallbackResult(
+                    status=200, body=json.dumps({"pop": Pop(components=[]).model_dump()})
+                )
+
+        mock.get(f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", callback=get_pop)
         endpoint = EyePopSdk.sync_worker(
             eyepop_url=self.test_eyepop_url,
             secret_key=self.test_eyepop_secret_key,
@@ -245,5 +388,5 @@ class TestEndpointConnect(BaseEndpointTest):
         self.assertEqual(auth_calls, 2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -163,6 +163,7 @@ class TestEndpointConnect(BaseEndpointTest):
         new_pop = Pop(components=[])
         captured_session_body = {}
         captured_pipeline_body = {}
+        call_order: list[str] = []
         session_response = {
             "session_uuid": "session-456",
             "session_endpoint": self.test_worker_url,
@@ -177,11 +178,17 @@ class TestEndpointConnect(BaseEndpointTest):
 
         def create_or_update_session(url, **kwargs) -> CallbackResult:
             captured_session_body.update(kwargs["json"])
+            call_order.append("session_post")
             return CallbackResult(status=200, body=json.dumps(session_response_without_pipeline))
 
         def create_pipeline(url, **kwargs) -> CallbackResult:
             captured_pipeline_body.update(kwargs["json"])
+            call_order.append("pipeline_post")
             return CallbackResult(status=200, body=json.dumps({"id": self.test_pipeline_id}))
+
+        def delete_pipeline(url, **kwargs) -> CallbackResult:
+            call_order.append("pipeline_delete")
+            return CallbackResult(status=204)
 
         mock.get(
             f"{self.test_eyepop_url}/v1/sessions", status=200, body=json.dumps([session_response])
@@ -196,7 +203,9 @@ class TestEndpointConnect(BaseEndpointTest):
             repeat=True,
         )
         mock.delete(
-            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", status=204, repeat=True
+            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}",
+            callback=delete_pipeline,
+            repeat=True,
         )
         mock.post(f"{self.test_worker_url}/pipelines", callback=create_pipeline)
         mock.get(
@@ -219,6 +228,8 @@ class TestEndpointConnect(BaseEndpointTest):
             self.assertEqual(response["id"], self.test_pipeline_id)
             self.assertEqual(captured_session_body["pop"], new_pop.model_dump())
             self.assertEqual(captured_pipeline_body["pop"], new_pop.model_dump())
+            self.assertLess(call_order.index("pipeline_delete"), call_order.index("session_post"))
+            self.assertLess(call_order.index("session_post"), call_order.index("pipeline_post"))
         finally:
             await endpoint.disconnect()
 
@@ -237,6 +248,69 @@ class TestEndpointConnect(BaseEndpointTest):
             },
             json={"pop": new_pop.model_dump()},
         )
+
+    @aioresponses()
+    async def test_set_pop_on_compute_transient_fails_before_recreate_when_delete_fails(
+        self, mock: aioresponses
+    ):
+        new_pop = Pop(components=[])
+        session_post_called = False
+        pipeline_post_called = False
+        session_response = {
+            "session_uuid": "session-456",
+            "session_endpoint": self.test_worker_url,
+            "access_token": self.test_access_token,
+            "pipelines": [{"pipeline_id": self.test_pipeline_id}],
+            "session_status": "running",
+        }
+
+        def create_or_update_session(url, **kwargs) -> CallbackResult:
+            nonlocal session_post_called
+            session_post_called = True
+            return CallbackResult(status=200, body=json.dumps({**session_response, "pipelines": []}))
+
+        def create_pipeline(url, **kwargs) -> CallbackResult:
+            nonlocal pipeline_post_called
+            pipeline_post_called = True
+            return CallbackResult(status=200, body=json.dumps({"id": self.test_pipeline_id}))
+
+        mock.get(
+            f"{self.test_eyepop_url}/v1/sessions", status=200, body=json.dumps([session_response])
+        )
+        mock.get(
+            f"{self.test_worker_url}/health",
+            status=200,
+            body=json.dumps({"message": "ok"}),
+            repeat=True,
+        )
+        mock.get(
+            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}",
+            status=200,
+            body=json.dumps({"pop": new_pop.model_dump(), "status": "IDLE"}),
+            repeat=True,
+        )
+        mock.delete(
+            f"{self.test_worker_url}/pipelines/{self.test_pipeline_id}", status=500, repeat=True
+        )
+        mock.post(
+            f"{self.test_eyepop_url}/v1/sessions?wait=true", callback=create_or_update_session
+        )
+        mock.post(f"{self.test_worker_url}/pipelines", callback=create_pipeline)
+
+        endpoint = EyePopSdk.async_worker(
+            eyepop_url=self.test_eyepop_url,
+            api_key="test-api-key",
+            pop_id="transient",
+            stop_jobs=False,
+        )
+        try:
+            await endpoint.connect()
+            with self.assertRaises(ClientResponseError):
+                await endpoint.set_pop(new_pop)
+            self.assertFalse(session_post_called)
+            self.assertFalse(pipeline_post_called)
+        finally:
+            await endpoint.disconnect()
 
     @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -18,6 +18,27 @@ class TestEndpointConnect(BaseEndpointTest):
         with self.assertRaises(KeyError):
             EyePopSdk.sync_worker()
 
+    def compute_transient_session_response(
+        self, pipelines: list[dict[str, str]] | None = None
+    ) -> dict:
+        if pipelines is None:
+            pipelines = [{"pipeline_id": self.test_pipeline_id}]
+        return {
+            "session_uuid": "session-456",
+            "session_endpoint": self.test_worker_url,
+            "access_token": self.test_access_token,
+            "pipelines": pipelines,
+            "session_status": "running",
+        }
+
+    def async_compute_transient_worker(self) -> WorkerEndpoint:
+        return EyePopSdk.async_worker(
+            eyepop_url=self.test_eyepop_url,
+            api_key="test-api-key",
+            pop_id="transient",
+            stop_jobs=False,
+        )
+
     def test_session_name_sets_compute_context(self):
         endpoint = EyePopSdk.async_worker(
             eyepop_url="https://compute.eyepop.ai",
@@ -164,17 +185,8 @@ class TestEndpointConnect(BaseEndpointTest):
         captured_session_body = {}
         captured_pipeline_body = {}
         call_order: list[str] = []
-        session_response = {
-            "session_uuid": "session-456",
-            "session_endpoint": self.test_worker_url,
-            "access_token": self.test_access_token,
-            "pipelines": [{"pipeline_id": self.test_pipeline_id}],
-            "session_status": "running",
-        }
-        session_response_without_pipeline = {
-            **session_response,
-            "pipelines": [],
-        }
+        session_response = self.compute_transient_session_response()
+        session_response_without_pipeline = self.compute_transient_session_response(pipelines=[])
 
         def create_or_update_session(url, **kwargs) -> CallbackResult:
             captured_session_body.update(kwargs["json"])
@@ -215,12 +227,7 @@ class TestEndpointConnect(BaseEndpointTest):
             repeat=True,
         )
 
-        endpoint = EyePopSdk.async_worker(
-            eyepop_url=self.test_eyepop_url,
-            api_key="test-api-key",
-            pop_id="transient",
-            stop_jobs=False,
-        )
+        endpoint = self.async_compute_transient_worker()
         try:
             await endpoint.connect()
             response = await endpoint.set_pop(new_pop)
@@ -256,13 +263,7 @@ class TestEndpointConnect(BaseEndpointTest):
         new_pop = Pop(components=[])
         session_post_called = False
         pipeline_post_called = False
-        session_response = {
-            "session_uuid": "session-456",
-            "session_endpoint": self.test_worker_url,
-            "access_token": self.test_access_token,
-            "pipelines": [{"pipeline_id": self.test_pipeline_id}],
-            "session_status": "running",
-        }
+        session_response = self.compute_transient_session_response()
 
         def create_or_update_session(url, **kwargs) -> CallbackResult:
             nonlocal session_post_called
@@ -297,12 +298,7 @@ class TestEndpointConnect(BaseEndpointTest):
         )
         mock.post(f"{self.test_worker_url}/pipelines", callback=create_pipeline)
 
-        endpoint = EyePopSdk.async_worker(
-            eyepop_url=self.test_eyepop_url,
-            api_key="test-api-key",
-            pop_id="transient",
-            stop_jobs=False,
-        )
+        endpoint = self.async_compute_transient_worker()
         try:
             await endpoint.connect()
             with self.assertRaises(ClientResponseError):


### PR DESCRIPTION
## Summary
- Makes transient SDK set_pop re-enter compute-api with the requested pop before replacing the pipeline.
- Deletes the old transient pipeline, waits for the compute session, then creates and waits for the replacement pipeline.
- Keeps persistent SDK set_pop on the existing worker-level path.

## Changes
- Posts pop-bearing transient session requests directly to compute for scheduling checks.
- Adds compute transient set_pop replacement flow and regression coverage.

## Test plan
- [x] task test
- [x] uv run pytest -q tests/test_compute_api.py tests/worker/test_endpoint_connect.py
- [x] uvx ruff check eyepop/compute/api.py eyepop/worker/worker_endpoint.py tests/test_compute_api.py tests/worker/test_endpoint_connect.py
- [x] uvx basedpyright eyepop/compute/api.py eyepop/worker/worker_endpoint.py tests/test_compute_api.py tests/worker/test_endpoint_connect.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved compute session reuse/creation behavior to speed up switching.
  * Enhanced pipeline lifecycle with optional readiness polling and clearer pipeline request/retry handling, including streaming-style `open_data`.
* **Bug Fixes**
  * Restructured compute session GET/create error handling and payload validation for more reliable session state.
  * Improved reconnect throttling and transient “rechecks” session scheduling, including correct pipeline cleanup ordering.
* **Tests**
  * Added coverage for transient “rechecks” scheduling and pipeline readiness/polling flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->