### PR TITLE
[SDK]: Treat transient pop as authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pop` support on worker session creation so transient compute sessions can be scheduled before starting a worker pipeline.
 
 ### Fixed
+- Transient compute workers now patch owned pipelines through the updated session endpoint after `set_pop()` triggers compute session rescheduling.
 - Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)
 
 ## [3.15.2] - 2026-04-27

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -48,36 +48,34 @@ async def fetch_new_compute_session(
     sessions_url = f"{compute_ctx.compute_url}/v1/sessions"
 
     res = None
-    need_new_session = False
+    need_new_session = compute_ctx.pop is not None
 
-    try:
-        async with client_session.get(sessions_url, headers=headers) as get_response:
-            log.debug(f"GET /v1/sessions - status: {get_response.status}")
-            if get_response.status == 404:
-                need_new_session = True
-            else:
-                get_response.raise_for_status()
-                res = await get_response.json()
-
-                if not res:
+    if not need_new_session:
+        try:
+            async with client_session.get(sessions_url, headers=headers) as get_response:
+                log.debug(f"GET /v1/sessions - status: {get_response.status}")
+                if get_response.status == 404:
                     need_new_session = True
-                elif isinstance(res, list):
-                    res = [s for s in res if isinstance(s, dict) and not s.get("persistent")]
+                else:
+                    get_response.raise_for_status()
+                    res = await get_response.json()
+
                     if not res:
                         need_new_session = True
-                elif isinstance(res, dict):
-                    if not res.get("session_uuid") or res.get("persistent"):
-                        need_new_session = True
+                    elif isinstance(res, list):
+                        res = [s for s in res if isinstance(s, dict) and not s.get("persistent")]
+                        if not res:
+                            need_new_session = True
+                    elif isinstance(res, dict):
+                        if not res.get("session_uuid") or res.get("persistent"):
+                            need_new_session = True
 
-    except aiohttp.ClientResponseError as e:
-        if e.status == 404:
-            need_new_session = True
-        else:
+        except aiohttp.ClientResponseError as e:
             raise ComputeSessionException(
                 f"Failed to fetch existing sessions: {e.message}",
             ) from e
-    except Exception as e:
-        raise ComputeSessionException(f"Unexpected error fetching sessions: {str(e)}") from e
+        except Exception as e:
+            raise ComputeSessionException(f"Unexpected error fetching sessions: {str(e)}") from e
 
     if need_new_session:
         try:
@@ -135,7 +133,7 @@ def _compute_context_from_response(compute_ctx: ComputeContext, res: dict | None
     compute_ctx.access_token_expires_at = session_response.access_token_expires_at
     compute_ctx.access_token_expires_in = session_response.access_token_expires_in
     pipeline_id = ""
-    if len(session_response.pipelines) > 0:
+    if compute_ctx.pop is None and len(session_response.pipelines) > 0:
         pipeline_id = session_response.pipelines[0].get("id", None)
         if not pipeline_id:
             pipeline_id = session_response.pipelines[0].get("pipeline_id", "")

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -115,6 +115,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             self.worker_config = None
             self._owns_pipeline_id = False
             if self._is_compute_transient():
+                assert self.compute_ctx is not None
                 self.compute_ctx.pipeline_id = ""
             return True
 
@@ -308,6 +309,9 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             self.worker_config["session_endpoint"] = self.compute_ctx.session_endpoint
             if not self._owns_pipeline_id:
                 self.worker_config["pipeline_id"] = ""
+
+        if self._owns_pipeline_id:
+            self._configure_load_balancer()
 
         if not self._has_pipeline_id():
             return await self._ensure_pipeline_started()

--- a/eyepop/worker/worker_endpoint.py
+++ b/eyepop/worker/worker_endpoint.py
@@ -96,6 +96,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             self.is_dev_mode = True
 
         self.worker_config = None
+        self._owns_pipeline_id = False
         self._pipeline_create_lock = asyncio.Lock()
         self.last_fetch_config_success_time = None
         self.last_fetch_config_error = None
@@ -103,12 +104,18 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
 
         self.add_retry_handler(404, self._retry_404)
 
+    def _is_compute_transient(self) -> bool:
+        return self.compute_ctx is not None and self.permanent_session_uuid is None
+
     async def _retry_404(self, status_code: int, failed_attempts: int) -> bool:
         if failed_attempts > 1:
             return False
         else:
             log_requests.debug('after 404, about to retry with fresh config')
             self.worker_config = None
+            self._owns_pipeline_id = False
+            if self._is_compute_transient():
+                self.compute_ctx.pipeline_id = ""
             return True
 
     async def _disconnect(self, timeout: float | None = None):
@@ -117,6 +124,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             client_timeout = aiohttp.ClientTimeout(total=timeout)
         if (self.is_dev_mode and self.pop_id == 'transient'
                 and self._has_pipeline_id()
+                and self._owns_pipeline_id
                 and self.client_session is not None):
             worker_config = self.worker_config
             assert worker_config is not None
@@ -131,7 +139,10 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             except Exception as e:
                 log.exception(e, exc_info=True)
             finally:
-                del worker_config["pipeline_id"]
+                worker_config.pop("pipeline_id", None)
+                self._owns_pipeline_id = False
+                if self.compute_ctx:
+                    self.compute_ctx.pipeline_id = ""
 
     async def _reconnect(self):
         # Narrow Optional[ClientSession] — _reconnect is only called after connect()
@@ -158,9 +169,14 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
                 self.eyepop_url = self.compute_ctx.session_endpoint
                 log_requests.debug(f"Compute session ready: {self.compute_ctx.session_endpoint}")
 
+            pipeline_id = self.compute_ctx.pipeline_id
+            self._owns_pipeline_id = False
+            if self._is_compute_transient():
+                pipeline_id = ""
+
             self.worker_config = {
                 "session_endpoint": self.compute_ctx.session_endpoint,
-                "pipeline_id": self.compute_ctx.pipeline_id,
+                "pipeline_id": pipeline_id,
                 "endpoints": [],
             }
 
@@ -207,7 +223,8 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
         if self.worker_config.get('status') == 'active_prod':
             self.is_dev_mode = False
 
-        if self.is_dev_mode and self.stop_jobs and self._has_pipeline_id():
+        if (self.is_dev_mode and self.stop_jobs and self._has_pipeline_id()
+                and (not self._is_compute_transient() or self._owns_pipeline_id)):
             stop_jobs_url = f'{await self.dev_mode_pipeline_base_url()}/source?mode=preempt&processing=sync'
             body = {'sourceType': 'NONE'}
             headers = {}
@@ -259,10 +276,42 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             self.compute_ctx.pop = pop.model_dump()
         if self.client_session is None:
             return {"pop": pop.model_dump()}
+        if self._is_compute_transient():
+            return await self._set_pop_on_compute_transient(pop)
         if self.worker_config is None:
             await self._reconnect()
         if self.is_dev_mode and not self._has_pipeline_id():
             return await self._ensure_pipeline_started()
+        response = await self.pipeline_patch('pop', content_type='application/json',
+                                             data=pop.model_dump_json())
+        return response
+
+    async def _set_pop_on_compute_transient(self, pop: Pop):
+        assert self.compute_ctx is not None
+        assert self.client_session is not None
+
+        self.compute_ctx.pop = pop.model_dump()
+        self.compute_ctx = await fetch_session_endpoint(
+            compute_ctx=self.compute_ctx,
+            client_session=self.client_session,
+            permanent_session_uuid=None,
+        )
+        self.eyepop_url = self.compute_ctx.session_endpoint
+
+        if self.worker_config is None:
+            self.worker_config = {
+                "session_endpoint": self.compute_ctx.session_endpoint,
+                "pipeline_id": "",
+                "endpoints": [],
+            }
+        else:
+            self.worker_config["session_endpoint"] = self.compute_ctx.session_endpoint
+            if not self._owns_pipeline_id:
+                self.worker_config["pipeline_id"] = ""
+
+        if not self._has_pipeline_id():
+            return await self._ensure_pipeline_started()
+
         response = await self.pipeline_patch('pop', content_type='application/json',
                                              data=pop.model_dump_json())
         return response
@@ -524,6 +573,7 @@ class WorkerEndpoint(Endpoint, WorkerClientSession):
             response_json = await response.json()
 
         self.worker_config['pipeline_id'] = response_json['id']
+        self._owns_pipeline_id = True
         if self.compute_ctx:
             self.compute_ctx.pipeline_uuid = response_json['id']
             self.compute_ctx.pipeline_id = response_json['id']

--- a/scripts/session_smoke.py
+++ b/scripts/session_smoke.py
@@ -134,16 +134,19 @@ def object_label(obj: dict[str, Any]) -> str:
     return ""
 
 
-def matching_objects(result: dict[str, Any], expected_class: str, min_confidence: float) -> list[dict[str, Any]]:
-    objects = result.get("objects") or []
-    if not isinstance(objects, list):
-        return []
+def _result_items(result: dict[str, Any]) -> list[dict[str, Any]]:
+    items = []
+    for key in ("objects", "classes"):
+        val = result.get(key) or []
+        if isinstance(val, list):
+            items.extend(obj for obj in val if isinstance(obj, dict))
+    return items
 
+
+def matching_objects(result: dict[str, Any], expected_class: str, min_confidence: float) -> list[dict[str, Any]]:
     matches = []
     expected = expected_class.strip().lower()
-    for obj in objects:
-        if not isinstance(obj, dict):
-            continue
+    for obj in _result_items(result):
         confidence = obj.get("confidence", 0)
         detected = object_label(obj).strip().lower()
         if detected == expected and isinstance(confidence, (int, float)) and confidence >= min_confidence:
@@ -159,9 +162,7 @@ def summarize_predictions(
     all_objects = []
     matches = []
     for result in predictions:
-        objects = result.get("objects") or []
-        if isinstance(objects, list):
-            all_objects.extend(obj for obj in objects if isinstance(obj, dict))
+        all_objects.extend(_result_items(result))
         matches.extend(matching_objects(result, expected_class, min_confidence))
 
     return {

--- a/scripts/session_smoke.py
+++ b/scripts/session_smoke.py
@@ -88,6 +88,12 @@ def parse_args() -> argparse.Namespace:
         help="Path to write machine-readable run summary.",
     )
     parser.add_argument(
+        "--pop-file",
+        type=Path,
+        default=None,
+        help="Path to a pop JSON file. When set, overrides --ability.",
+    )
+    parser.add_argument(
         "--no-cleanup",
         action="store_true",
         help="Skip transient session deletion. Intended only for local debugging.",
@@ -108,8 +114,14 @@ def require_inputs(args: argparse.Namespace) -> None:
     if not args.image.is_file():
         raise FileNotFoundError(f"Image fixture does not exist: {args.image}")
 
+    if args.pop_file is not None and not args.pop_file.is_file():
+        raise FileNotFoundError(f"Pop fixture does not exist: {args.pop_file}")
+
 
 def build_pop(args: argparse.Namespace) -> Pop:
+    if args.pop_file is not None:
+        raw = json.loads(args.pop_file.read_text())
+        return Pop(**raw)
     component = cast(
         DynamicComponent,
         InferenceComponent(
@@ -119,11 +131,7 @@ def build_pop(args: argparse.Namespace) -> Pop:
             model=None,
         ),
     )
-    return Pop(
-        components=[
-            component
-        ]
-    )
+    return Pop(components=[component])
 
 
 def object_label(obj: dict[str, Any]) -> str:
@@ -227,7 +235,8 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
         "sdk_version": __version__,
         "eyepop_url": eyepop_url,
         "image": str(args.image),
-        "ability": args.ability,
+        "pop_file": str(args.pop_file) if args.pop_file else "",
+        "ability": str(args.pop_file) if args.pop_file else args.ability,
         "expected_class": args.expected_class,
         "min_objects": args.min_objects,
         "min_confidence": args.min_confidence,

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -103,6 +103,45 @@ async def test_creates_session_with_pop_for_scheduling(aioresponses):
 
 
 @pytest.mark.asyncio
+async def test_pop_is_authoritative_when_transient_exists(aioresponses):
+    pop = {"components": [{"type": "inference", "ability": "eyepop.person:latest"}]}
+    ctx = ComputeContext(
+        compute_url="https://compute.staging.eyepop.xyz",
+        api_key="test-api-key",
+        pop=pop,
+    )
+    captured_body = {}
+
+    def configure_session(url, **kwargs):
+        captured_body.update(kwargs["json"])
+        return CallbackResult(body=json.dumps({
+            **MOCK_SESSION_RESPONSE,
+            "pipelines": [{"pipeline_id": "stale-pipeline"}],
+        }), status=200)
+
+    aioresponses.get(
+        "https://compute.staging.eyepop.xyz/v1/sessions",
+        payload=[{
+            **MOCK_SESSION_RESPONSE,
+            "session_uuid": "existing-transient",
+            "pipelines": [{"pipeline_id": "stale-pipeline"}],
+            "persistent": False,
+        }],
+        status=200
+    )
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true",
+        callback=configure_session
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_new_compute_session(ctx, session)
+
+    assert captured_body["pop"] == pop
+    assert result.pipeline_id == ""
+
+
+@pytest.mark.asyncio
 async def test_creates_session_without_pop_when_unset(mock_compute_config, aioresponses):
     captured_body = {}
 

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -136,6 +136,62 @@ class TestEndpointConnect(BaseEndpointTest):
         self.assertBaseMock(mock, is_transient=True, expect_pipeline_started=False)
 
     @aioresponses()
+    async def test_compute_transient_set_pop_does_not_patch_shared_pipeline(
+        self, mock: aioresponses
+    ):
+        new_pop = Pop(components=[])
+        captured_session_body = {}
+        captured_pipeline_body = {}
+        shared_pipeline_id = "shared-pipeline"
+        owned_pipeline_id = "owned-pipeline"
+        session_response = {
+            "session_uuid": "session-456",
+            "session_endpoint": self.test_worker_url,
+            "access_token": self.test_access_token,
+            "pipelines": [{"pipeline_id": shared_pipeline_id}],
+            "session_status": "running",
+            "persistent": False,
+        }
+
+        def configure_session(url, **kwargs) -> CallbackResult:
+            captured_session_body.update(kwargs["json"])
+            return CallbackResult(status=200, body=json.dumps(session_response))
+
+        def create_pipeline(url, **kwargs) -> CallbackResult:
+            captured_pipeline_body.update(kwargs["json"])
+            return CallbackResult(status=200, body=json.dumps({"id": owned_pipeline_id}))
+
+        mock.get(
+            "https://compute.eyepop.ai/v1/sessions",
+            status=200,
+            body=json.dumps([session_response]),
+        )
+        mock.get(
+            f"{self.test_worker_url}/health",
+            status=200,
+            body=json.dumps({"message": "ok"}),
+            repeat=True,
+        )
+        mock.post("https://compute.eyepop.ai/v1/sessions?wait=true", callback=configure_session)
+        mock.post(f"{self.test_worker_url}/pipelines", callback=create_pipeline)
+        mock.delete(f"{self.test_worker_url}/pipelines/{owned_pipeline_id}", status=204)
+
+        endpoint = EyePopSdk.async_worker(
+            eyepop_url="https://compute.eyepop.ai",
+            api_key="test-api-key",
+            pop_id="transient",
+        )
+        try:
+            await endpoint.connect()
+            response = await endpoint.set_pop(new_pop)
+        finally:
+            await endpoint.disconnect()
+
+        self.assertEqual(response["id"], owned_pipeline_id)
+        self.assertEqual(captured_session_body["pop"], new_pop.model_dump())
+        self.assertEqual(captured_pipeline_body["pop"], new_pop.model_dump())
+
+    @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):
         self.setup_base_mock(mock)
 

--- a/tests/worker/test_endpoint_connect.py
+++ b/tests/worker/test_endpoint_connect.py
@@ -192,6 +192,88 @@ class TestEndpointConnect(BaseEndpointTest):
         self.assertEqual(captured_pipeline_body["pop"], new_pop.model_dump())
 
     @aioresponses()
+    async def test_compute_transient_set_pop_patches_owned_pipeline_on_updated_endpoint(
+        self, mock: aioresponses
+    ):
+        old_worker_url = "http://old-worker.test"
+        new_worker_url = "http://new-worker.test"
+        owned_pipeline_id = "owned-pipeline"
+        initial_pop = Pop(components=[])
+        new_pop = Pop(components=[])
+        session_responses = [
+            {
+                "session_uuid": "session-456",
+                "session_endpoint": old_worker_url,
+                "access_token": self.test_access_token,
+                "pipelines": [],
+                "session_status": "running",
+                "persistent": False,
+            },
+            {
+                "session_uuid": "session-456",
+                "session_endpoint": old_worker_url,
+                "access_token": self.test_access_token,
+                "pipelines": [],
+                "session_status": "running",
+                "persistent": False,
+            },
+            {
+                "session_uuid": "session-456",
+                "session_endpoint": new_worker_url,
+                "access_token": self.test_access_token,
+                "pipelines": [{"pipeline_id": owned_pipeline_id}],
+                "session_status": "running",
+                "persistent": False,
+            },
+        ]
+        old_patch_calls = []
+        new_patch_calls = []
+
+        def configure_session(url, **kwargs) -> CallbackResult:
+            return CallbackResult(status=200, body=json.dumps(session_responses.pop(0)))
+
+        def create_pipeline(url, **kwargs) -> CallbackResult:
+            return CallbackResult(status=200, body=json.dumps({"id": owned_pipeline_id}))
+
+        def patch_old_pipeline(url, **kwargs) -> CallbackResult:
+            old_patch_calls.append(kwargs)
+            return CallbackResult(status=200, body=json.dumps({"endpoint": "old"}))
+
+        def patch_new_pipeline(url, **kwargs) -> CallbackResult:
+            new_patch_calls.append(kwargs)
+            return CallbackResult(status=200, body=json.dumps({"endpoint": "new"}))
+
+        mock.get(
+            "https://compute.eyepop.ai/v1/sessions",
+            status=200,
+            body=json.dumps([session_responses.pop(0)]),
+        )
+        mock.get(f"{old_worker_url}/health", status=200, body=json.dumps({"message": "ok"}), repeat=True)
+        mock.get(f"{new_worker_url}/health", status=200, body=json.dumps({"message": "ok"}), repeat=True)
+        mock.post("https://compute.eyepop.ai/v1/sessions?wait=true", callback=configure_session, repeat=True)
+        mock.post(f"{old_worker_url}/pipelines", callback=create_pipeline)
+        mock.patch(f"{old_worker_url}/pipelines/{owned_pipeline_id}/pop", callback=patch_old_pipeline)
+        mock.patch(f"{new_worker_url}/pipelines/{owned_pipeline_id}/pop", callback=patch_new_pipeline)
+        mock.delete(f"{new_worker_url}/pipelines/{owned_pipeline_id}", status=204)
+
+        endpoint = EyePopSdk.async_worker(
+            eyepop_url="https://compute.eyepop.ai",
+            api_key="test-api-key",
+            pop_id="transient",
+        )
+        try:
+            await endpoint.connect()
+            await endpoint.set_pop(initial_pop)
+            response = await endpoint.set_pop(new_pop)
+        finally:
+            await endpoint.disconnect()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(old_patch_calls, [])
+        self.assertEqual(len(new_patch_calls), 1)
+        self.assertEqual(json.loads(new_patch_calls[0]["data"]), new_pop.model_dump())
+
+    @aioresponses()
     def test_connect_unauthorized(self, mock: aioresponses):
         self.setup_base_mock(mock)
 


### PR DESCRIPTION
## Summary
- Treat `pop=` as authoritative for transient compute scheduling by sending it through `POST /v1/sessions?wait=true`.
- Keep transient sessions shared/reused, but treat pipeline IDs as local SDK endpoint handles unless this endpoint created them.
- Prevent the SDK from binding to, stopping, patching, or deleting arbitrary pipelines returned by a shared transient session listing.

## Contract
- compute-api owns transient CPU/GPU scheduling and upgrade decisions.
- The SDK owns expressing the requested pop and managing only its local pipeline handle.
- A transient session may be shared by multiple clients using the same API key/user; returned session `pipelines` are observational state, not proof of SDK ownership.

## Test Plan
- [x] `uv run --extra test pytest tests/worker/test_endpoint_connect.py::TestEndpointConnect::test_compute_transient_set_pop_does_not_patch_shared_pipeline -q`
- [x] `uv run --extra test pytest tests/test_compute_api.py tests/worker/test_endpoint_connect.py tests/worker/test_endpoint_pop.py tests/worker/test_endpoint_pop_comp.py -q`
- [x] `uv run --extra test pytest -q`
- [x] `uvx ruff check eyepop/compute/api.py eyepop/worker/worker_endpoint.py tests/test_compute_api.py tests/worker/test_endpoint_connect.py`

## Staging Smoke Results (SDK `3.17.1.dev215285`)
- **1a GPU person**: `eyepop.person:latest` → 23 persons, confidence 0.93–0.97 ✓
- **1b CPU ModelLess**: `eyepop.localize-objects:latest` w/ `params.prompts` → 41 objects ✓
- **1d VLM find-kittens**: `eyepop-ai-ryan.find-events.find-kittens:latest` → class `SAW_KITTEN` ✓
- **CPU→GPU upgrade path**: session `c8bcffd6` UUID preserved across 3 invocations; K8s deployment rolled from `nodeSelector: null` → `compute-class: gpu-t4-shared-6`; CPU pop on GPU node stays on GPU node (no downgrade) ✓