### PR TITLE
[CI]: Add shared secret scan workflow

### DIFF
--- a/.github/trufflehog/eyepop-detectors.yml
+++ b/.github/trufflehog/eyepop-detectors.yml
@@ -1,0 +1,6 @@
+detectors:
+  - name: eyepop-api-key
+    keywords:
+      - eyp_
+    regex:
+      key: '\beyp_[A-Za-z0-9_-]{50,}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,11 +16,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: eyepop-ai/eyepop-actions
           ref: main
@@ -35,9 +35,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9
 
       - run: uv sync --locked --all-extras --dev
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - run: uv sync --locked --all-extras --dev
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install dependencies
       run: uv sync --locked --all-extras --dev

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,10 +18,10 @@ jobs:
     env:
       EYEPOP_URL: ${{ vars.EYEPOP_URL }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v9
 
     - name: Install dependencies
       run: uv sync --locked --all-extras --dev

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,7 +56,7 @@ jobs:
         echo "Proper wheel contents!"
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@v1.14.1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
@@ -56,7 +56,7 @@ jobs:
         echo "Proper wheel contents!"
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -19,4 +19,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: eyepop-ai/eyepop-actions/secret-scan@v1.3.0
+      - uses: trufflesecurity/trufflehog@v3.95.9
+        with:
+          extra_args: >-
+            --config=.github/trufflehog/eyepop-detectors.yml
+            --results=verified,unknown

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: eyepop-ai/eyepop-actions/secret-scan@main
+      - uses: eyepop-ai/eyepop-actions/secret-scan@v1.3.0

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,22 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: eyepop-ai/eyepop-actions/secret-scan@main

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -37,12 +37,12 @@ jobs:
       EYEPOP_URL: ${{ vars.EYEPOP_URL }}
       SUMMARY_JSON: session-smoke-summary.json
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        uses: astral-sh/setup-uv@v9
 
       - name: Install SDK under test
         run: |
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload smoke summary
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: sessions-smoke-summary-${{ env.SMOKE_ENVIRONMENT }}
           path: ${{ env.SUMMARY_JSON }}

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Install SDK under test
         run: |

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
@@ -71,7 +71,7 @@ jobs:
       run: uv run pytest
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -71,7 +71,7 @@ jobs:
       run: uv run pytest
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@v1.14.1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -28,7 +28,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
## Summary
- Add the shared EyePop TruffleHog secret scan workflow.
- Run scans on pull requests, pushes to `main`, weekly full-history sweeps, and manual dispatch.

## Changes
- Add `.github/workflows/secret-scan.yaml` using `eyepop-ai/eyepop-actions/secret-scan@main`.
- Checkout with full history so scheduled and manual scans can cover repository history.

## Test plan
- [x] `yq e '.' .github/workflows/secret-scan.yaml`