### PR TITLE
docs: concise CLAUDE.md agent guide + gitignore agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,19 @@ CLAUDE.local.md
 !.claude/skills/
 !CLAUDE.md
 .claude/settings.local.json
+
+# Agent / planning artifacts — never committed (untracked, kept local)
+HANDOFF.md
+CONTEXT.md
+docs/CONTEXT.md
+docs/CONTEXT-MAP.md
+docs/adr/
+docs/adrs/
+docs/prd/
+docs/prds/
+docs/pdr/
+docs/issues/
+docs/agents/
+docs/superpowers/
+superpowers/
+docs/postmortems/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# eyepop-sdk-python
+
+Official EyePop.ai Python SDK (`eyepop` on PyPI) — async/sync client for the Worker (CV inference)
+and Data (datasets / VLM / evaluation) APIs. Runs on `uv`, Python ≥ 3.12.
+
+## Commands
+`task --list-all` for tasks. Run `task check` before done (lint + typecheck-changed + test).
+
+## Gotchas
+- Typecheck gate is **basedpyright**, not mypy — despite a `[tool.mypy]` block + mypy in dev deps. Fixing
+  types against mypy won't match CI.
+- Integration tests hit **real EyePop endpoints** and are skipped by default (`addopts = --ignore=tests/integration`,
+  and each needs `EYEPOP_API_KEY`). They run nightly or manually (`uv run pytest tests/integration/ --timeout=300`).
+- Version is git-derived (`setuptools_scm`) — building from a worktree/shallow clone misversions; publish asserts
+  `eyepop.__version__ == release tag` with `fetch-depth: 0`.
+- Auth env is layered: `EYEPOP_API_KEY` (or `EYEPOP_ACCESS_TOKEN`); `EYEPOP_ACCOUNT_ID` required for the Data API;
+  `EYEPOP_URL` defaults to **production** — override for staging. `EYEPOP_SECRET_KEY` is deprecated. In the
+  composable-pop API, `model=`/`modelUuid=` are deprecated (use `ability=`) and `set_pop()` takes only `Pop` objects.
+
+## See also
+- `.claude/skills/eyepop-sdk` — SDK usage patterns, auth/vault, composable Pop, examples


### PR DESCRIPTION
Adds a concise, standardized `CLAUDE.md` (agent onboarding) to this repo.

**CLAUDE.md** — one-line purpose, `task --list-all` check-gate pointer, and non-obvious gotchas only. No directory maps, command dumps, or speculative filler (discoverable info deliberately excluded).

**Hygiene**
- `.gitignore`: ignore agent/planning artifacts (adr/prd/context/handoff/superpowers/postmortems)

Part of a fleet-wide agent-config standardization across EyePop repos.