### PR TITLE
[SDK]: Await transient pipeline creation before ownership check

### DIFF
--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -53,6 +53,15 @@ jobs:
             uv venv
             if [[ "$SDK_VERSION" == "latest" ]]; then
               uv pip install --upgrade eyepop
+            elif [[ "$SDK_VERSION" == *.dev* || "$SDK_VERSION" == *rc* ]]; then
+              # Pre-release builds (e.g. per-push TestPyPI dev packages) live on TestPyPI;
+              # pull the package from there while resolving deps across both indexes
+              # (unsafe-best-match lets deps like aiohttp resolve from PyPI instead of
+              # TestPyPI's stale mirror).
+              uv pip install --prerelease allow \
+                --extra-index-url https://test.pypi.org/simple/ \
+                --index-strategy unsafe-best-match \
+                "eyepop==$SDK_VERSION"
             else
               uv pip install "eyepop==$SDK_VERSION"
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pop` support on worker session creation so transient compute sessions can be scheduled before starting a worker pipeline.
 
 ### Fixed
+- Transient sessions started with a `pop` now wait for the compute API to finish creating the pipeline before reporting an ownership failure. Previously the SDK checked pipeline ownership on the initial session response and raised immediately, so a session created a moment before its pipeline row landed (common right after a compute API deploy) failed spuriously. The client-visible "did not return an owned pipeline" error is preserved for sessions that genuinely never receive a pipeline.
 - Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)
 
 ## [3.15.2] - 2026-04-27

--- a/eyepop/compute/api.py
+++ b/eyepop/compute/api.py
@@ -5,7 +5,7 @@ from typing import Any
 import aiohttp
 from pydantic import TypeAdapter
 
-from eyepop.compute.context import ComputeContext
+from eyepop.compute.context import ComputeContext, first_pipeline_id
 from eyepop.compute.responses import ComputeApiSessionResponse
 from eyepop.compute.status import wait_for_session
 from eyepop.exceptions import ComputeSessionException, ComputeTokenException
@@ -119,11 +119,6 @@ async def fetch_new_compute_session(
             res = None
 
     _compute_context_from_response(compute_ctx, res)
-    if compute_ctx.pop is not None and not compute_ctx.pipeline_owned:
-        raise ComputeSessionException(
-            "Transient compute session did not return an owned pipeline",
-            session_uuid=compute_ctx.session_uuid,
-        )
 
     return compute_ctx
 
@@ -141,12 +136,7 @@ def _compute_context_from_response(compute_ctx: ComputeContext, res: dict | None
     compute_ctx.m2m_access_token = session_response.access_token
     compute_ctx.access_token_expires_at = session_response.access_token_expires_at
     compute_ctx.access_token_expires_in = session_response.access_token_expires_in
-    pipeline_id = ""
-    if len(session_response.pipelines) > 0:
-        pipeline_id = session_response.pipelines[0].get("id", None)
-        if not pipeline_id:
-            pipeline_id = session_response.pipelines[0].get("pipeline_id", "")
-
+    pipeline_id = first_pipeline_id(session_response.pipelines)
     compute_ctx.pipeline_id = pipeline_id
     compute_ctx.pipeline_owned = bool(compute_ctx.pop is not None and pipeline_id)
 

--- a/eyepop/compute/context.py
+++ b/eyepop/compute/context.py
@@ -55,8 +55,7 @@ class ComputeContext(BaseModel):
 def first_pipeline_id(pipelines: list[dict]) -> str:
     if not pipelines:
         return ""
-    first = pipelines[0]
-    return first.get("id") or first.get("pipeline_id", "")
+    return pipelines[0].get("pipeline_id", "")
 
 
 class PipelineStatus(str, Enum):

--- a/eyepop/compute/context.py
+++ b/eyepop/compute/context.py
@@ -52,6 +52,13 @@ class ComputeContext(BaseModel):
     )
 
 
+def first_pipeline_id(pipelines: list[dict]) -> str:
+    if not pipelines:
+        return ""
+    first = pipelines[0]
+    return first.get("id") or first.get("pipeline_id", "")
+
+
 class PipelineStatus(str, Enum):
     UNKNOWN = "unknown"
     PENDING = "pending"

--- a/eyepop/compute/status.py
+++ b/eyepop/compute/status.py
@@ -4,9 +4,9 @@ import logging
 import aiohttp
 from pydantic import ValidationError
 
-from eyepop.compute.context import ComputeContext, PipelineStatus
+from eyepop.compute.context import ComputeContext, PipelineStatus, first_pipeline_id
 from eyepop.compute.responses import ComputeApiSessionResponse
-from eyepop.exceptions import ComputeHealthCheckException
+from eyepop.exceptions import ComputeHealthCheckException, ComputeSessionException
 
 log = logging.getLogger("eyepop.compute")
 
@@ -67,7 +67,14 @@ async def wait_for_session(
                 status = session_response.session_status
                 log.debug(f"GET /health - status: 200, pipeline: {status.value} (attempt {attempt})")
 
-                if status == PipelineStatus.RUNNING:
+                pipeline_id = first_pipeline_id(session_response.pipelines)
+                if pipeline_id:
+                    compute_config.pipeline_id = pipeline_id
+                    compute_config.pipeline_owned = compute_config.pop is not None
+
+                awaiting_pipeline = compute_config.pop is not None and not compute_config.pipeline_owned
+
+                if status == PipelineStatus.RUNNING and not awaiting_pipeline:
                     return True
 
                 if status in _TERMINAL_STATES:
@@ -78,7 +85,11 @@ async def wait_for_session(
                         last_status=status.value,
                     )
 
-                last_message = f"Pipeline status: {status.value}"
+                last_message = (
+                    "Awaiting owned pipeline creation"
+                    if awaiting_pipeline
+                    else f"Pipeline status: {status.value}"
+                )
                 await asyncio.sleep(interval)
 
         except ComputeHealthCheckException:
@@ -91,6 +102,12 @@ async def wait_for_session(
             last_message = str(e)
             log.debug(f"GET /health - error: {last_message} (attempt {attempt})")
             await asyncio.sleep(interval)
+
+    if compute_config.pop is not None and not compute_config.pipeline_owned:
+        raise ComputeSessionException(
+            "Transient compute session did not return an owned pipeline",
+            session_uuid=compute_config.session_uuid,
+        )
 
     log.error(f"Session timed out after {timeout}s. Last message: {last_message}")
     raise TimeoutError(f"Session timed out after {timeout}s. Last message: {last_message}")

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -100,7 +100,12 @@ async def test_creates_session_with_pop_for_scheduling(aioresponses):
 
 
 @pytest.mark.asyncio
-async def test_pop_transient_session_requires_returned_pipeline(aioresponses):
+async def test_pop_transient_session_without_pipeline_defers_ownership(aioresponses):
+    """A pop session whose POST response has no pipeline yet must not fail here.
+
+    Ownership is resolved during the readiness wait (the pipeline may still be
+    creating), so session creation records an unowned pipeline rather than raising.
+    """
     pop = {"components": [{"type": "inference", "model": "yolo"}], "postTransform": None}
     ctx = ComputeContext(
         compute_url="https://compute.staging.eyepop.xyz",
@@ -115,8 +120,46 @@ async def test_pop_transient_session_requires_returned_pipeline(aioresponses):
     )
 
     async with aiohttp.ClientSession() as session:
-        with pytest.raises(ComputeSessionException):
-            await fetch_new_compute_session(ctx, session)
+        result = await fetch_new_compute_session(ctx, session)
+
+    assert result.pipeline_id == ""
+    assert not result.pipeline_owned
+
+
+@pytest.mark.asyncio
+async def test_transient_session_waits_for_pipeline_creation(aioresponses):
+    """Deploy-window race: session ready before the pipeline row lands.
+
+    The pipeline appears on a later /health poll; the SDK must wait, not fail.
+    """
+    pop = {"components": [{"type": "inference", "model": "yolo"}], "postTransform": None}
+    ctx = ComputeContext(
+        compute_url="https://compute.staging.eyepop.xyz",
+        api_key="test-api-key",
+        pop=pop,
+        wait_for_session_timeout=10,
+        wait_for_session_interval=1,
+    )
+
+    aioresponses.post(
+        "https://compute.staging.eyepop.xyz/v1/sessions?wait=true&transient=true",
+        payload=MOCK_SESSION_RESPONSE_NO_PIPELINES,
+        status=200,
+    )
+    aioresponses.get(
+        "https://pipeline.example.com/health",
+        payload={**MOCK_SESSION_RESPONSE_NO_PIPELINES, "session_status": "pipeline_creating"},
+    )
+    aioresponses.get(
+        "https://pipeline.example.com/health",
+        payload=MOCK_SESSION_RESPONSE,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        result = await fetch_session_endpoint(ctx, session, None)
+
+    assert result.pipeline_id == "pipeline-123"
+    assert result.pipeline_owned
 
 
 @pytest.mark.asyncio

--- a/tests/test_compute_status.py
+++ b/tests/test_compute_status.py
@@ -3,7 +3,7 @@ import pytest
 
 from eyepop.compute.context import ComputeContext, PipelineStatus
 from eyepop.compute.status import wait_for_session
-from eyepop.exceptions import ComputeHealthCheckException
+from eyepop.exceptions import ComputeHealthCheckException, ComputeSessionException
 
 HEALTH_URL = "https://session.example.com/health"
 
@@ -96,6 +96,50 @@ async def test_times_out_when_never_ready(aioresponses):
     async with aiohttp.ClientSession() as session:
         with pytest.raises(TimeoutError, match="timed out"):
             await wait_for_session(_config(wait_for_session_timeout=1), session)
+
+
+@pytest.mark.asyncio
+async def test_pop_session_waits_for_pipeline_then_owns(aioresponses):
+    """A pop session stays not-ready until an owned pipeline appears."""
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "pipeline_creating",
+        "pipelines": [],
+    })
+    aioresponses.get(HEALTH_URL, payload={
+        "session_uuid": "s1",
+        "session_endpoint": "https://session.example.com",
+        "access_token": "tok",
+        "session_status": "running",
+        "pipelines": [{"pipeline_id": "pl-1"}],
+    })
+
+    ctx = _config(pop={"components": []})
+    async with aiohttp.ClientSession() as session:
+        assert await wait_for_session(ctx, session) is True
+
+    assert ctx.pipeline_id == "pl-1"
+    assert ctx.pipeline_owned
+
+
+@pytest.mark.asyncio
+async def test_pop_session_running_without_pipeline_raises_session_exception(aioresponses):
+    """RUNNING but never an owned pipeline → the intended client-visible error, not a timeout."""
+    for _ in range(100):
+        aioresponses.get(HEALTH_URL, payload={
+            "session_uuid": "s1",
+            "session_endpoint": "https://session.example.com",
+            "access_token": "tok",
+            "session_status": "running",
+            "pipelines": [],
+        })
+
+    ctx = _config(pop={"components": []}, wait_for_session_timeout=1)
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(ComputeSessionException):
+            await wait_for_session(ctx, session)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes the spurious `ComputeSessionException: "Transient compute session did not return an owned pipeline"` that fails transient (`pop`) sessions when the compute API returns the session a beat before its pipeline row lands — the failure mode the production sessions smoke hit on 2026-07-08/09, right after the v3.17.1 deploy.
- The check was a **timing** bug, not an error-handling one: ownership was asserted on the initial `POST /v1/sessions` response with a 0s budget, *before* the 60s readiness poll ran. The intended client-visible error is kept — it now fires only after the pipeline genuinely never materializes.

## Changes
- `eyepop/compute/api.py` — remove the premature ownership raise from `fetch_new_compute_session`; it now just records initial pipeline state. Reuse a shared extractor.
- `eyepop/compute/context.py` — add pure `first_pipeline_id(pipelines)` helper (shared by api + status).
- `eyepop/compute/status.py` — `wait_for_session` refreshes `pipeline_id`/`pipeline_owned` from each `/health` poll and treats a `pop` session as ready only once it owns a pipeline (waits through `pipeline_creating`). On timeout with no owned pipeline it raises the same `ComputeSessionException` outward.
- Tests + CHANGELOG.

## Behavior notes
- Genuine bad-pop / never-created-pipeline still errors outward: via `ComputeHealthCheckException` immediately if the pipeline goes terminal (`failed`/`error`), or via the preserved `ComputeSessionException` after the readiness timeout otherwise.
- Non-`pop` sessions are unaffected (gate reduces to the prior `RUNNING` check).

## Test plan
- [x] `uv run pytest` — 148 passed
- [x] `uvx ruff check` (changed) — clean
- [x] `uvx basedpyright` (changed) — 0 errors
- [ ] Reviewer sanity-check on the readiness-gate semantics in `wait_for_session`