### PR TITLE
[CI]: Support manual release dispatch with auto-generated release notes

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,13 +3,19 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, e.g. 3.17.2 (no leading 'v')"
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -19,6 +25,38 @@ jobs:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
+    - name: Resolve version and tag
+      id: version
+      env:
+        RAW: ${{ github.event.release.tag_name || inputs.version }}
+      run: |
+        set -euo pipefail
+        TAG="$RAW"
+        [[ "$TAG" == v* ]] || TAG="v$TAG"
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+    # When run manually (not from a UI-published release), create the GitHub
+    # Release ourselves with auto-generated notes so the Releases UI and PyPI
+    # stay in sync. A release created with GITHUB_TOKEN does not re-fire the
+    # `release: published` event, so this same run must also publish below.
+    - name: Create GitHub Release with auto-generated notes
+      if: github.event_name == 'workflow_dispatch'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.version.outputs.tag }}
+      run: |
+        set -euo pipefail
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          echo "Release $TAG already exists; skipping creation."
+        else
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --generate-notes
+        fi
+        git fetch --tags --force
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
@@ -33,13 +71,11 @@ jobs:
       run: uvx --from build pyproject-build --installer uv
 
     - name: Sanity check version matches tag...
+      env:
+        EXPECTED_VERSION: ${{ steps.version.outputs.version }}
       run: |
         uv pip install dist/*.whl
         BUILT_VERSION=$(uv run python -c "import eyepop; print(eyepop.__version__)")
-        RELEASE_TAG="${{ github.event.release.tag_name }}"
-
-        # Strip v prefix if it's there
-        EXPECTED_VERSION="${RELEASE_TAG#v}"
 
         if [ "$BUILT_VERSION" != "$EXPECTED_VERSION" ]; then
           echo "ERROR: Built version ($BUILT_VERSION) does not match release tag ($EXPECTED_VERSION)"
@@ -60,4 +96,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `session_name` support on worker session creation, also configurable via `EYEPOP_SESSION_NAME`.
 - `pop` support on worker session creation so transient compute sessions can be scheduled before starting a worker pipeline.
 
+### Changed
+- The PyPI publish workflow can be run manually via `workflow_dispatch` with a version input; when triggered that way it creates the matching GitHub Release with auto-generated notes before publishing, so the Releases page and PyPI stay in sync without a hand-drafted UI release.
+
 ### Fixed
 - Transient sessions started with a `pop` now wait for the compute API to finish creating the pipeline before reporting an ownership failure. Previously the SDK checked pipeline ownership on the initial session response and raised immediately, so a session created a moment before its pipeline row landed (common right after a compute API deploy) failed spuriously. The client-visible "did not return an owned pipeline" error is preserved for sessions that genuinely never receive a pipeline.
 - Worker connections without a `session_uuid` no longer adopt an existing persistent session. The compute API session list is now filtered by the new `persistent` flag so ephemeral connections always pick (or create) an ephemeral session, and persistent sessions are only reachable when their UUID is passed explicitly. (AWSU-166)


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` (version input) to the PyPI publish workflow so releases can be cut programmatically, not only by drafting a release in the UI.
- On a manual dispatch it creates the matching GitHub Release with **auto-generated notes** (`gh release create --generate-notes`) before publishing — so the Releases page and PyPI stay in sync. UI-published releases are unchanged (create step skipped).

## Why one workflow (not a separate release-creator)
A GitHub Release created with `GITHUB_TOKEN` does **not** re-fire the `release: published` event, so a separate publish workflow would never trigger. Creating the release and building/publishing in the same job avoids that and any double-publish.

## Behavior
- `release: published` (UI) → create step skipped → build + publish (as before).
- `workflow_dispatch(version)` → create GitHub Release + tag with auto notes (idempotent — skips if the tag already exists) → build + publish in the same run.
- Version input accepts `3.17.2` or `v3.17.2`; setuptools_scm reads the created tag; the existing built-version-vs-tag sanity check still guards both paths.

## Notes
- Requires `contents: write` (added) for `GITHUB_TOKEN` to create the release/tag. If org policy blocks `GITHUB_TOKEN` from creating releases, swap `github.token` for a PAT secret (as eyepop-vlm does with `GH_TOKEN`).
- `workflow_dispatch` only becomes available once this lands on `main` (default branch requirement).

## Test plan
- [x] YAML parses; version-resolution logic verified for `3.17.2` and `v3.17.2`
- [ ] After merge: dispatch `Upload Python Package` with `version=3.17.2` to cut the transient-fix release and confirm the GitHub Release + notes + PyPI upload