### PR TITLE
[Python SDK]: Correct authentication and VLM examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with EyePopSdk.sync_worker() as endpoint:
 Set `EYEPOP_API_KEY` in your environment (get one at [dashboard.eyepop.ai](https://dashboard.eyepop.ai)), or pass `api_key=...` to `sync_worker()`:
 
 ```python
-endpoint = EyePopSdk.sync_worker(api_key='my-api-key', pop_id='my-pop-id')
+endpoint = EyePopSdk.sync_worker(api_key='my-api-key')
 ```
 
 ## Configuration
@@ -32,6 +32,7 @@ Credentials are read from environment variables. Set **one** auth method:
 |---|---|
 | `EYEPOP_API_KEY` | API key from your dashboard. |
 | `EYEPOP_ACCESS_TOKEN` | Pre-issued OAuth access token. |
+| `EYEPOP_SECRET_KEY` | Secret key for a named pop. |
 
 Optional:
 
@@ -218,8 +219,7 @@ pop = Pop(components=[
         params={'prompts': [{'prompt': 'person'}]},
         forward=CropForward(targets=[
             InferenceComponent(
-                ability='eyepop.image-contents:latest',
-                params={'prompts': [{'prompt': 'hair color?'}]},
+                ability='my-company.describe-hair-color:latest',
             ),
         ]),
     ),


### PR DESCRIPTION
## Summary
- stop combining API-key authentication with named pops
- document the named-pop secret credential
- replace the deprecated inline VLM ability example

## Validation
- uv sync --extra test
- task check